### PR TITLE
Correct content type

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
+require "jsonapi"
+
 class ApplicationController < ActionController::API
+  before_action :verify_content_type_header, :verify_accept_header
+
   rescue_from ActiveRecord::RecordInvalid do |exception|
     render_errors exception.record.errors.full_messages, :unprocessable_entity
   end
@@ -7,11 +11,37 @@ class ApplicationController < ActionController::API
     render_errors exception.message
   end
 
+  rescue_from JSONAPI::NotAcceptableError do |exception|
+    render_errors exception.message, :not_acceptable
+  end
+
+  rescue_from JSONAPI::UnsupportedMediaTypeError do |exception|
+    render_errors exception.message, :unsupported_media_type
+  end
+
   protected
 
   def render_errors(messages, status=:bad_request)
     errors = [messages].flatten
 
     render json: { errors: errors }, status: status
+  end
+
+  def verify_accept_header
+    unless request.accept == JSONAPI::MEDIA_TYPE ||
+           request.accept.start_with?("*/*")
+      raise JSONAPI::NotAcceptableError.new(request.accept)
+    end
+  end
+
+  def verify_content_type_header
+    # This is needed because Rails returns a :bad_request (400) instead
+    # of a :unsupported_media_type (415) for invalid content-type headers
+    # There is a PR to fix this: https://github.com/rails/rails/pull/26632
+    if request.post? || request.put? || request.patch?
+      unless request.content_type == JSONAPI::MEDIA_TYPE
+        raise JSONAPI::UnsupportedMediaTypeError.new(request.content_type)
+      end
+    end
   end
 end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,2 +1,4 @@
+require "jsonapi"
+
 Mime::Type.unregister :json
-Mime::Type.register "application/vnd.api+json", :json
+Mime::Type.register JSONAPI::MEDIA_TYPE, :json

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,4 +1,2 @@
-# Be sure to restart your server when you modify this file.
-
-# Add new mime types for use in respond_to blocks:
-# Mime::Type.register "text/richtext", :rtf
+Mime::Type.unregister :json
+Mime::Type.register "application/vnd.api+json", :json

--- a/lib/jsonapi.rb
+++ b/lib/jsonapi.rb
@@ -1,0 +1,21 @@
+module JSONAPI
+  MEDIA_TYPE = "application/vnd.api+json"
+
+  class NotAcceptableError < RuntimeError
+    attr_reader :media_type
+
+    def initialize(media_type)
+      @media_type = media_type
+      super "Not Acceptable"
+    end
+  end
+
+  class UnsupportedMediaTypeError < RuntimeError
+    attr_reader :media_type
+
+    def initialize(media_type)
+      @media_type = media_type
+      super "Unsupported Media Type"
+    end
+  end
+end

--- a/spec/requests/register_players_spec.rb
+++ b/spec/requests/register_players_spec.rb
@@ -3,6 +3,12 @@ require "rails_helper"
 RSpec.describe "POST /api/players" do
   let(:avatar) { "THIS NEEDS TO BE A BASE64 STRING" }
   let(:json_response) { JSON.parse(response.body).deep_symbolize_keys }
+  let(:valid_headers) do
+    {
+      "Accept": JSONAPI::MEDIA_TYPE,
+      "Content-type": JSONAPI::MEDIA_TYPE
+    }
+  end
   let(:valid_parameters) do
     {
       data: {
@@ -15,33 +21,34 @@ RSpec.describe "POST /api/players" do
           avatar: avatar
         }
       }
-    }
+    }.to_json
   end
 
   context "with a valid request" do
     let(:player) { Player.unscoped.last }
 
     it "returns the correct status" do
-      post "/api/players", params: valid_parameters
+      post "/api/players", params: valid_parameters, headers: valid_headers
 
       expect(response).to be_created
     end
 
     it "creates a player" do
-      expect { post "/api/players", params: valid_parameters }.to \
+      expect { post "/api/players", params: valid_parameters,
+                                    headers: valid_headers }.to \
         change { Player.count }.by 1
 
       expect(player.email_address).to eq "jimmy@example.com"
     end
 
     it "generates an api key for the player" do
-      post "/api/players", params: valid_parameters
+      post "/api/players", params: valid_parameters, headers: valid_headers
 
       expect(player.api_key).to_not be_blank
     end
 
     it "returns the json representation of a player" do
-      post "/api/players", params: valid_parameters
+      post "/api/players", params: valid_parameters, headers: valid_headers
 
       expect(json_response[:data][:type]).to eq "player"
       expect(json_response[:data][:id]).to eq player.id.to_s
@@ -56,11 +63,11 @@ RSpec.describe "POST /api/players" do
           email_address: "jimmy@example.com",
           password: "p@ssword",
         }
-      }
+      }.to_json
     end
 
     it "returns a bad request status" do
-      post "/api/players", params: parameters
+      post "/api/players", params: parameters, headers: valid_headers
 
       expect(response).to be_bad_request
       expect(json_response[:errors]).to \
@@ -77,28 +84,38 @@ RSpec.describe "POST /api/players" do
             email_address: "jimmy@example.com",
           }
         }
-      }
+      }.to_json
     end
 
     it "returns an unprocessable entity status" do
-      post "/api/players", params: parameters
+      post "/api/players", params: parameters, headers: valid_headers
 
       expect(response.status).to eq 422
       expect(json_response[:errors]).to include "Password can't be blank"
     end
 
     it "does not create the player" do
-      expect { post "/api/players", params: parameters }.to_not \
+      expect { post "/api/players", params: parameters,
+                                    headers: valid_headers }.to_not \
         change { Player.count }
     end
   end
 
-  context "without a correct json content type" do
-    it "returns a bad request status" do
+  context "without a correct accept header" do
+    it "returns a not acceptable status" do
       post "/api/players", params: valid_parameters,
-                           headers: { "Content-type": "application/xml" }
+        headers: valid_headers.merge("Accept": "application/json")
 
-      expect(response).to be_bad_request
+      expect(response).to have_http_status(:not_acceptable)
+    end
+  end
+
+  context "without a correct content type header" do
+    it "returns an unsupported media type status" do
+      post "/api/players", params: valid_parameters,
+        headers: valid_headers.merge("Content-type": "application/json")
+
+      expect(response).to have_http_status(:unsupported_media_type)
     end
   end
 end


### PR DESCRIPTION
This PR restricts requests to the correct `Content-Type` and `Accept` headers. It follows the [JSONAPI spec](http://jsonapi.org/format/#content-negotiation-servers) by returning a status code of `415` if the `Content-Type` header is not `application/vnd.api+json` for a post, put, or patch request. If returns a `406` if the `Accept` header is not of media type `application/vnd.api+json` for all requests.

Closes https://trello.com/c/SHVV4yCy/5-use-correct-content-type-header