### PR TITLE
Arena play endpoint

### DIFF
--- a/app/controllers/api/arenas_controller.rb
+++ b/app/controllers/api/arenas_controller.rb
@@ -10,6 +10,6 @@ class API::ArenasController < ApplicationController
     player_arena = PlayerArena.create! player_id: current_user.id,
                                        arena_id: params[:id],
                                        joined_at: DateTime.now
-    head :ok
+    render json: PlayerArenaSerializer.new(player_arena).serialized_json
   end
 end

--- a/app/controllers/api/arenas_controller.rb
+++ b/app/controllers/api/arenas_controller.rb
@@ -7,6 +7,9 @@ class API::ArenasController < ApplicationController
   end
 
   def play
+    player_arena = PlayerArena.create! player_id: current_user.id,
+                                       arena_id: params[:id],
+                                       joined_at: DateTime.now
     head :ok
   end
 end

--- a/app/controllers/api/arenas_controller.rb
+++ b/app/controllers/api/arenas_controller.rb
@@ -8,10 +8,18 @@ class API::ArenasController < ApplicationController
 
   def play
     arena = Arena.find params[:id]
-    player_arena = PlayerArena.create! player_id: current_user.id,
-                                       arena: arena,
-                                       joined_at: DateTime.now
+
+    player_arena = PlayerArena.find_by player_id: current_user.id, arena: arena
+    if player_arena.nil?
+      player_arena = PlayerArena.create! player_id: current_user.id,
+                                         arena: arena,
+                                         joined_at: DateTime.now
+      status = :created
+    else
+      status = :ok
+    end
+
     render json: PlayerArenaSerializer.new(player_arena).serialized_json,
-           status: :created
+           status: status
   end
 end

--- a/app/controllers/api/arenas_controller.rb
+++ b/app/controllers/api/arenas_controller.rb
@@ -11,6 +11,7 @@ class API::ArenasController < ApplicationController
     player_arena = PlayerArena.create! player_id: current_user.id,
                                        arena: arena,
                                        joined_at: DateTime.now
-    render json: PlayerArenaSerializer.new(player_arena).serialized_json
+    render json: PlayerArenaSerializer.new(player_arena).serialized_json,
+           status: :created
   end
 end

--- a/app/controllers/api/arenas_controller.rb
+++ b/app/controllers/api/arenas_controller.rb
@@ -7,8 +7,9 @@ class API::ArenasController < ApplicationController
   end
 
   def play
+    arena = Arena.find params[:id]
     player_arena = PlayerArena.create! player_id: current_user.id,
-                                       arena_id: params[:id],
+                                       arena: arena,
                                        joined_at: DateTime.now
     render json: PlayerArenaSerializer.new(player_arena).serialized_json
   end

--- a/app/controllers/api/arenas_controller.rb
+++ b/app/controllers/api/arenas_controller.rb
@@ -5,4 +5,8 @@ class API::ArenasController < ApplicationController
     arenas = Arena.near([params[:latitude], params[:longitude]], 5)
     render json: ArenaSerializer.new(arenas).serialized_json
   end
+
+  def play
+    head :ok
+  end
 end

--- a/app/controllers/api/players_controller.rb
+++ b/app/controllers/api/players_controller.rb
@@ -1,7 +1,6 @@
 class API::PlayersController < ApplicationController
   def create
-    player = Player.new player_params.merge(api_key: TokenGenerator.generate)
-    player.save!
+    player = Player.create! player_params.merge(api_key: TokenGenerator.generate)
 
     render json: PlayerSerializer.new(player).serialized_json,
            status: :created

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,12 @@ class ApplicationController < ActionController::API
     render_errors exception.record.errors.full_messages, :unprocessable_entity
   end
 
+  rescue_from ActiveRecord::RecordNotFound do |exception|
+    exception = "#{exception.model} with #{exception.primary_key} "\
+                "#{exception.id} not found"
+    render_errors exception, :not_found
+  end
+
   rescue_from ActionController::ParameterMissing do |exception|
     render_errors exception.message
   end

--- a/app/models/player_arena.rb
+++ b/app/models/player_arena.rb
@@ -1,0 +1,4 @@
+class PlayerArena < ApplicationRecord
+  belongs_to :player
+  belongs_to :arena
+end

--- a/app/serializers/player_arena_serializer.rb
+++ b/app/serializers/player_arena_serializer.rb
@@ -1,0 +1,9 @@
+require "fast_jsonapi"
+
+class PlayerArenaSerializer
+  include FastJsonapi::ObjectSerializer
+
+  set_type :player_arena
+  attributes :joined_at
+  belongs_to :arena
+end

--- a/app/serializers/player_arena_serializer.rb
+++ b/app/serializers/player_arena_serializer.rb
@@ -7,7 +7,16 @@ class PlayerArenaSerializer
   attributes :joined_at
   belongs_to :arena
 
-  def joined_at
-    record.joined_at.to_i
+  def initialize(resource, options={})
+    super
+    @record = PlayerArenaDecorator.new(@record)
+  end
+
+  private
+
+  class PlayerArenaDecorator < SimpleDelegator
+    def joined_at
+      __getobj__.joined_at.to_i
+    end
   end
 end

--- a/app/serializers/player_arena_serializer.rb
+++ b/app/serializers/player_arena_serializer.rb
@@ -6,4 +6,8 @@ class PlayerArenaSerializer
   set_type :player_arena
   attributes :joined_at
   belongs_to :arena
+
+  def joined_at
+    record.joined_at.to_i
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
-    resources :arenas, only: :index
+    resources :arenas, only: :index do
+      post :play, on: :member
+    end
     resources :players, only: :create
   end
 end

--- a/db/migrate/20180219164434_create_player_arenas.rb
+++ b/db/migrate/20180219164434_create_player_arenas.rb
@@ -1,0 +1,11 @@
+class CreatePlayerArenas < ActiveRecord::Migration[5.1]
+  def change
+    create_table :player_arenas do |t|
+      t.references :player, foreign_key: true
+      t.references :arena, foreign_key: true
+      t.datetime :joined_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180215021843) do
+ActiveRecord::Schema.define(version: 20180219164434) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,16 @@ ActiveRecord::Schema.define(version: 20180215021843) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "player_arenas", force: :cascade do |t|
+    t.bigint "player_id"
+    t.bigint "arena_id"
+    t.datetime "joined_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["arena_id"], name: "index_player_arenas_on_arena_id"
+    t.index ["player_id"], name: "index_player_arenas_on_player_id"
+  end
+
   create_table "players", force: :cascade do |t|
     t.string "email_address", null: false
     t.string "crypted_password", null: false
@@ -39,4 +49,6 @@ ActiveRecord::Schema.define(version: 20180215021843) do
     t.string "name", null: false
   end
 
+  add_foreign_key "player_arenas", "arenas"
+  add_foreign_key "player_arenas", "players"
 end

--- a/spec/factories/player_arena_factory.rb
+++ b/spec/factories/player_arena_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :player_arena do
+    player
+    arena
+    joined_at { 2.days.ago }
+  end
+end

--- a/spec/requests/arena_play_spec.rb
+++ b/spec/requests/arena_play_spec.rb
@@ -48,8 +48,13 @@ RSpec.describe "POST /api/arenas/:id/play" do
     end
   end
 
-  context "without a valid authorization header" do
-    xit "returns an unauthorized request status"
+  it_behaves_like "an authenticated request" do
+    let(:make_request) do
+      -> (headers) do
+        post "/api/arenas/#{arena.id}/play", params: valid_parameters,
+                                             headers: valid_headers.merge(headers)
+      end
+    end
   end
 
   it_behaves_like "a request responding to correct headers" do

--- a/spec/requests/arena_play_spec.rb
+++ b/spec/requests/arena_play_spec.rb
@@ -1,0 +1,16 @@
+require "request_helper"
+
+RSpec.describe "POST /api/arenas/:id/play" do
+  let(:arena) { create :arena }
+  let(:player) { create :player, :authorized }
+  let(:valid_parameters) { {}.to_json }
+
+  context "with a valid request" do
+    it "returns an ok status" do
+      post "/api/arenas/#{arena.id}/play", params: valid_parameters,
+                                           headers: valid_authed_headers
+
+      expect(response).to be_ok
+    end
+  end
+end

--- a/spec/requests/arena_play_spec.rb
+++ b/spec/requests/arena_play_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe "POST /api/arenas/:id/play" do
       expect(player_arena.arena).to eq arena
     end
 
-    xit "returns a JSON representation of the arena joined"
+    it "returns a JSON representation of the player arena" do
+      post "/api/arenas/#{arena.id}/play", params: valid_parameters,
+                                           headers: valid_authed_headers
+
+      expect(json_response[:data][:type]).to eq "player_arena"
+      expect(json_response[:data][:id]).to eq player_arena.id.to_s
+    end
   end
 end

--- a/spec/requests/arena_play_spec.rb
+++ b/spec/requests/arena_play_spec.rb
@@ -6,11 +6,24 @@ RSpec.describe "POST /api/arenas/:id/play" do
   let(:valid_parameters) { {}.to_json }
 
   context "with a valid request" do
+    let(:player_arena) { PlayerArena.unscoped.last }
+
     it "returns an ok status" do
       post "/api/arenas/#{arena.id}/play", params: valid_parameters,
                                            headers: valid_authed_headers
 
       expect(response).to be_ok
     end
+
+    it "joins the player to the arena" do
+      expect { post "/api/arenas/#{arena.id}/play", params: valid_parameters,
+               headers: valid_authed_headers }.to \
+               change { PlayerArena.count }.by 1
+      expect(player_arena.joined_at).to be_within(1.second).of(DateTime.now)
+      expect(player_arena.player).to eq player
+      expect(player_arena.arena).to eq arena
+    end
+
+    xit "returns a JSON representation of the arena joined"
   end
 end

--- a/spec/requests/arena_play_spec.rb
+++ b/spec/requests/arena_play_spec.rb
@@ -32,4 +32,32 @@ RSpec.describe "POST /api/arenas/:id/play" do
       expect(json_response[:data][:id]).to eq player_arena.id.to_s
     end
   end
+
+  context "with an invalid arena id" do
+    it "returns a not found status" do
+      post "/api/arenas/1234/play", params: valid_parameters,
+                                    headers: valid_authed_headers
+
+      expect(response.status).to eq 404
+      expect(json_response[:errors]).to include "Arena with id 1234 not found"
+    end
+
+    it "does not create the player arena" do
+      expect { post "/api/arenas/1234/play", params: valid_parameters,
+               headers: valid_authed_headers }.to_not change { PlayerArena.count }
+    end
+  end
+
+  context "without a valid authorization header" do
+    xit "returns an unauthorized request status"
+  end
+
+  it_behaves_like "a request responding to correct headers" do
+    let(:make_request) do
+      -> (headers) do
+        post "/api/arenas/#{arena.id}/play", params: valid_parameters,
+                                             headers: valid_headers.merge(headers)
+      end
+    end
+  end
 end

--- a/spec/requests/arena_play_spec.rb
+++ b/spec/requests/arena_play_spec.rb
@@ -33,6 +33,22 @@ RSpec.describe "POST /api/arenas/:id/play" do
     end
   end
 
+  context "with an arena already joined" do
+    let!(:player_arena) { create :player_arena, player: player, arena: arena }
+
+    it "returns an ok status" do
+      post "/api/arenas/#{arena.id}/play", params: valid_parameters,
+                                           headers: valid_authed_headers
+
+      expect(response).to be_ok
+    end
+
+    it "does not create a new player arena" do
+      expect { post "/api/arenas/1234/play", params: valid_parameters,
+               headers: valid_authed_headers }.to_not change { PlayerArena.count }
+    end
+  end
+
   context "with an invalid arena id" do
     it "returns a not found status" do
       post "/api/arenas/1234/play", params: valid_parameters,

--- a/spec/requests/arena_play_spec.rb
+++ b/spec/requests/arena_play_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe "POST /api/arenas/:id/play" do
   context "with a valid request" do
     let(:player_arena) { PlayerArena.unscoped.last }
 
-    it "returns an ok status" do
+    it "returns a created status" do
       post "/api/arenas/#{arena.id}/play", params: valid_parameters,
                                            headers: valid_authed_headers
 
-      expect(response).to be_ok
+      expect(response).to be_created
     end
 
     it "joins the player to the arena" do

--- a/spec/requests/nearby_arenas_spec.rb
+++ b/spec/requests/nearby_arenas_spec.rb
@@ -36,14 +36,11 @@ RSpec.describe "GET /api/arenas" do
     end
   end
 
-  context "without a valid authorization header" do
-    it "returns an unauthorized request status" do
-      not_authed_headers = valid_authed_headers.merge("Authorization": "Bearer BLAH")
-
-      get "/api/arenas", params: valid_parameters, headers: not_authed_headers
-
-      expect(response).to be_unauthorized
-      expect(json_response[:errors]).to eq ["Not authorized"]
+  it_behaves_like "an authenticated request" do
+    let(:make_request) do
+      -> (headers) do
+        get "/api/arenas", params: valid_parameters, headers: valid_headers.merge(headers)
+      end
     end
   end
 

--- a/spec/serializers/player_arena_serializer_spec.rb
+++ b/spec/serializers/player_arena_serializer_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe PlayerArenaSerializer do
+  let(:player_arena) { create :player_arena }
+
+  subject { described_class.new(player_arena) }
+
+  describe "#serializable_hash" do
+    let(:hash) { subject.serializable_hash[:data] }
+
+    it "serializes the type" do
+      expect(hash[:type]).to eq :player_arena
+    end
+
+    it "serializes the id" do
+      expect(hash[:id]).to eq player_arena.id.to_s
+    end
+
+    it "serializes the attributes" do
+      expect(hash[:attributes].keys).to match_array [:joined_at]
+    end
+
+    it "serializes the relationships" do
+      expect(hash[:relationships].keys).to match_array [:arena]
+      expect(hash[:relationships][:arena][:data][:id]).to \
+        eq player_arena.arena_id.to_s
+    end
+  end
+end

--- a/spec/serializers/player_arena_serializer_spec.rb
+++ b/spec/serializers/player_arena_serializer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe PlayerArenaSerializer do
 
     it "serializes the attributes" do
       expect(hash[:attributes].keys).to match_array [:joined_at]
-      expect(Time.at(hash[:attributes][:joined_at])).to be_a Time
+      expect(hash[:attributes][:joined_at]).to be_a Integer
     end
 
     it "serializes the relationships" do

--- a/spec/serializers/player_arena_serializer_spec.rb
+++ b/spec/serializers/player_arena_serializer_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe PlayerArenaSerializer do
 
     it "serializes the attributes" do
       expect(hash[:attributes].keys).to match_array [:joined_at]
+      expect(Time.at(hash[:attributes][:joined_at])).to be_a Time
     end
 
     it "serializes the relationships" do

--- a/spec/shared_examples/request.rb
+++ b/spec/shared_examples/request.rb
@@ -17,3 +17,14 @@ RSpec.shared_examples "a request responding to correct headers" do
     end
   end
 end
+
+RSpec.shared_examples "an authenticated request" do
+  context "without a valid authorization header" do
+    it "returns an unauthorized request status" do
+      make_request.call("Authorization": "Bearer BLAH")
+
+      expect(response).to be_unauthorized
+      expect(json_response[:errors]).to eq ["Not authorized"]
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the endpoint for `POST /api/arenas/:id/play` which will link the current player to the arena so they can play in that arena.

This adds an error handler for a record that could not be found and responds with a 404 if the model with the id could not be found.

A new `PlayerArena` model was created when the player is associated with the arena.

Closes [Arena Play Endpoint](https://trello.com/c/yU6qpN2t/7-arena-play-endpoint)