### PR TITLE
Login endpoint

### DIFF
--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -1,0 +1,5 @@
+class API::SessionsController < ApplicationController
+  def create
+    head :ok
+  end
+end

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -4,6 +4,8 @@ class API::SessionsController < ApplicationController
                                  player_params[:password])
 
     if player
+      player.generate_api_key!(false)
+
       render json: PlayerSerializer.new(player).serialized_json
     else
       raise JSONAPI::UnauthorizedError

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -1,5 +1,17 @@
 class API::SessionsController < ApplicationController
   def create
-    head :ok
+    player = Player.authenticate(player_params[:email_address],
+                                 player_params[:password])
+
+    render json: PlayerSerializer.new(player).serialized_json
+  end
+
+  private
+
+  def player_params
+    params.require(:data)
+          .require(:attributes)
+          .permit(:email_address,
+                  :password)
   end
 end

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -3,7 +3,11 @@ class API::SessionsController < ApplicationController
     player = Player.authenticate(player_params[:email_address],
                                  player_params[:password])
 
-    render json: PlayerSerializer.new(player).serialized_json
+    if player
+      render json: PlayerSerializer.new(player).serialized_json
+    else
+      raise JSONAPI::UnauthorizedError
+    end
   end
 
   private

--- a/app/documentation/root.rb
+++ b/app/documentation/root.rb
@@ -2,6 +2,7 @@ require "jsonapi"
 require "swagger/blocks"
 require_relative "arenas"
 require_relative "players"
+require_relative "sessions"
 
 module Documentation
   module Root
@@ -9,6 +10,7 @@ module Documentation
       base.send :include, Swagger::Blocks
       base.send :include, Arenas
       base.send :include, Players
+      base.send :include, Sessions
 
       base.class_eval do
         swagger_root do
@@ -42,6 +44,9 @@ module Documentation
           end
           tag name: "PLAYERS" do
             key :description, "Player operations"
+          end
+          tag name: "SESSIONS" do
+            key :description, "Session operations"
           end
         end
       end

--- a/app/documentation/sessions.rb
+++ b/app/documentation/sessions.rb
@@ -1,0 +1,74 @@
+module Documentation
+  module Sessions
+    def self.included(base)
+      base.class_eval do
+
+        swagger_path "/sessions" do
+          operation :post do
+            key :summary, "Logs in a player"
+            key :description, "Logs in a player with an email and password."
+            key :tags, ["SESSIONS"]
+            parameter do
+              key :name, :attributes
+              key :type, :object
+              key :in, :body
+              key :description, "The email address and password to log in with"
+              schema do
+                key :"$ref", :AuthenticationInput
+              end
+            end
+            response 200 do
+              key :description, "A JSON API formatted representation of a single Player"
+              schema do
+                key :"$ref", :Player
+              end
+              example name: JSONAPI::MEDIA_TYPE do
+                key :data, [{
+                  id: "12345",
+                  type: "player",
+                  attributes: {
+                    name: "Jimmy Page",
+                    email_address: "jimmy@example.org",
+                    avatar: "SOME BASE 64 STRING",
+                    api_key: "API_TOKEN",
+                  }
+                }]
+              end
+            end
+            response 401 do
+              key :description, "Unauthorized"
+              schema do
+                key :type, :string
+              end
+              example name: JSONAPI::MEDIA_TYPE do
+                key :errors, "Not authorized"
+              end
+            end
+          end
+        end
+
+        swagger_schema :AuthenticationInput do
+          key :type, :object
+          key :required, [:data]
+          property :data do
+            key :type, :object
+            key :required, [:attributes]
+            property :attributes do
+              key :type, :object
+              key :required, [:email_address, :password]
+              property :email_address do
+                key :type, :string
+                key :description, "Email address for the player"
+              end
+              property :password do
+                key :type, :string
+                key :description, "Password for the player"
+              end
+            end
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -14,8 +14,19 @@ class Player < ApplicationRecord
   validates :name, presence: true
   validates :password, presence: true, if: proc { |u| u.crypted_password_changed? }
 
+  def self.authenticate(email_address, password)
+    player = with_email_address(email_address)
+    return nil unless player
+    player if PasswordEncryptor.matches?(password, player.crypted_password, player.salt)
+  end
+
   def self.with_api_key(api_key)
     where(api_key: api_key).first unless api_key.blank?
+  end
+
+  def self.with_email_address(email_address)
+    where("LOWER(email_address) = :email_address",
+          email_address: (email_address || "").downcase).first
   end
 
   private

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -4,7 +4,7 @@ require "token_generator"
 class Player < ApplicationRecord
   attr_accessor :password
 
-  before_validation :encrypt_password, on: [:create, :update]
+  before_validation :encrypt_password, if: proc { |p| p.password }
   after_save :clear_virtual_password
 
   validates :email_address, presence: true,
@@ -12,7 +12,8 @@ class Player < ApplicationRecord
                             uniqueness: { case_sensitive: false,
                                           message: "has already been registered" }
   validates :name, presence: true
-  validates :password, presence: true, if: proc { |u| u.crypted_password_changed? }
+  validates :password, presence: true,
+                       if: proc { |p| p.new_record? || p.crypted_password_changed? }
 
   def self.authenticate(email_address, password)
     player = with_email_address(email_address)

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -29,6 +29,11 @@ class Player < ApplicationRecord
           email_address: (email_address || "").downcase).first
   end
 
+  def generate_api_key!(force=true)
+    return false if !force && !api_key.blank?
+    update_attributes(api_key: TokenGenerator.generate)
+  end
+
   private
 
   def clear_virtual_password

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:api_key, :password]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
       post :play, on: :member
     end
     resources :players, only: :create
+    resources :sessions, only: :create
   end
 
   resources :docs, path: "/api/docs", only: :index

--- a/lib/password_encryptor.rb
+++ b/lib/password_encryptor.rb
@@ -4,4 +4,11 @@ class PasswordEncryptor
   def self.encrypt(password, salt)
     ::BCrypt::Password.create([password, salt].join, cost: 10)
   end
+
+  def self.matches?(password, crypted_password, salt)
+    return false if crypted_password.nil?
+    hash = ::BCrypt::Password.new(crypted_password)
+    return false if hash.nil? || hash.empty?
+    hash == [password, salt].join
+  end
 end

--- a/spec/lib/password_encryptor_spec.rb
+++ b/spec/lib/password_encryptor_spec.rb
@@ -19,4 +19,34 @@ RSpec.describe PasswordEncryptor do
       expect(result1).to_not eq result2
     end
   end
+
+  describe ".matches?" do
+    let(:password) { "hello world" }
+    let(:salt) { "123456788" }
+    let(:crypted_password) { described_class.encrypt password, salt }
+
+    it "returns true if password matches encrypted password" do
+      result = described_class.matches? password, crypted_password, salt
+
+      expect(result).to be_truthy
+    end
+
+    it "returns false if password doesn't match encrypted password" do
+      result = described_class.matches? "blah", crypted_password, salt
+
+      expect(result).to be_falsey
+    end
+
+    it "returns false if password is nil" do
+      result = described_class.matches? nil, crypted_password, salt
+
+      expect(result).to be_falsey
+    end
+
+    it "returns encrypted password  if password is nil" do
+      result = described_class.matches? password, nil, salt
+
+      expect(result).to be_falsey
+    end
+  end
 end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -26,6 +26,32 @@ RSpec.describe Player do
     end
   end
 
+  describe "#generate_api_key!" do
+    let(:current_api_key) { "API_KEY" }
+
+    subject { build :player, api_key: current_api_key }
+
+    it "generates a new api key" do
+      subject.generate_api_key!
+
+      expect(subject.api_key).to_not eq current_api_key
+    end
+
+    it "optionally does not generate a new one if it's not nil" do
+      subject.generate_api_key! false
+
+      expect(subject.api_key).to eq current_api_key
+    end
+
+    it "generates a new one if it's nil" do
+      subject.api_key = nil
+
+      subject.generate_api_key! false
+
+      expect(subject.api_key).to_not be_nil
+    end
+  end
+
   describe "#password" do
     subject { build :player }
 

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -1,6 +1,31 @@
 require "rails_helper"
 
 RSpec.describe Player do
+  describe ".authenticate" do
+    let(:password) { "p@ssword" }
+
+    subject { create :player, password: password }
+
+    context "with the correct email and password" do
+      it "returns the player" do
+        expect(described_class.authenticate(subject.email_address, password)).to \
+          eq subject
+      end
+    end
+
+    context "with an incorrect email address" do
+      it "returns nil" do
+        expect(described_class.authenticate("blah", password)).to be_nil
+      end
+    end
+
+    context "with an incorrect password" do
+      it "returns nil" do
+        expect(described_class.authenticate(subject.email_address, "blah")).to be_nil
+      end
+    end
+  end
+
   describe "#password" do
     subject { build :player }
 
@@ -35,6 +60,23 @@ RSpec.describe Player do
       subject.update_attributes api_key: nil
 
       expect(described_class.with_api_key(nil)).to be_nil
+    end
+  end
+
+  describe ".with_email_address" do
+    subject { create :player }
+
+    it "returns the player with the specified email address" do
+      expect(described_class.with_email_address(subject.email_address.upcase)).to \
+        eq subject
+    end
+
+    it "returns nil if the player is not found" do
+      expect(described_class.with_email_address("blah")).to be_nil
+    end
+
+    it "returns nil if the email address is nil" do
+      expect(described_class.with_email_address(nil)).to be_nil
     end
   end
 

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Player do
 
     it "requires a password on update when changing" do
       subject = create :player
-      subject.password = nil
+      subject.password = ""
 
       expect(subject).to_not be_valid
       expect(subject.errors[:password]).to include "can't be blank"

--- a/spec/requests/login_spec.rb
+++ b/spec/requests/login_spec.rb
@@ -29,4 +29,24 @@ RSpec.describe "POST /api/sessions" do
       expect(json_response[:data][:id]).to eq player.id.to_s
     end
   end
+
+  context "with invalid email address" do
+    let(:parameters) do
+      {
+        data: {
+          attributes: {
+            email_address: "someone-else@example.com",
+            password: password
+          }
+        }
+      }.to_json
+    end
+
+    it "returns an unauthorized status" do
+      post "/api/sessions", params: parameters, headers: valid_headers
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(json_response[:errors]).to include "Not authorized"
+    end
+  end
 end

--- a/spec/requests/login_spec.rb
+++ b/spec/requests/login_spec.rb
@@ -22,6 +22,21 @@ RSpec.describe "POST /api/sessions" do
       expect(response).to be_ok
     end
 
+    it "generates an api key for the user" do
+      post "/api/sessions", params: valid_parameters, headers: valid_headers
+
+      expect(player.reload.api_key).to_not be_blank
+    end
+
+    it "does not regenerate the api key for the user if one already exists" do
+      api_key = "API_KEY"
+      player.update_attributes(api_key: api_key)
+
+      post "/api/sessions", params: valid_parameters, headers: valid_headers
+
+      expect(player.reload.api_key).to eq api_key
+    end
+
     it "returns the json representation of a player" do
       post "/api/sessions", params: valid_parameters, headers: valid_headers
 

--- a/spec/requests/login_spec.rb
+++ b/spec/requests/login_spec.rb
@@ -49,4 +49,13 @@ RSpec.describe "POST /api/sessions" do
       expect(json_response[:errors]).to include "Not authorized"
     end
   end
+
+  it_behaves_like "a request responding to correct headers" do
+    let(:make_request) do
+      -> (headers) do
+        post "/api/sessions", params: valid_parameters,
+                              headers: valid_headers.merge(headers)
+      end
+    end
+  end
 end

--- a/spec/requests/login_spec.rb
+++ b/spec/requests/login_spec.rb
@@ -1,0 +1,25 @@
+require "request_helper"
+
+RSpec.describe "POST /api/sessions" do
+  let(:password) { "p@ssword" }
+  let(:player) { create :player, password: password }
+  let(:valid_parameters) do
+    {
+      data: {
+        type: "player",
+        attributes: {
+          email_address: player.email_address,
+          password: password
+        }
+      }
+    }.to_json
+  end
+
+  context "with a valid request" do
+    it "returns an ok status" do
+      post "/api/sessions", params: valid_parameters, headers: valid_headers
+
+      expect(response).to be_ok
+    end
+  end
+end

--- a/spec/requests/login_spec.rb
+++ b/spec/requests/login_spec.rb
@@ -21,5 +21,12 @@ RSpec.describe "POST /api/sessions" do
 
       expect(response).to be_ok
     end
+
+    it "returns the json representation of a player" do
+      post "/api/sessions", params: valid_parameters, headers: valid_headers
+
+      expect(json_response[:data][:type]).to eq "player"
+      expect(json_response[:data][:id]).to eq player.id.to_s
+    end
   end
 end


### PR DESCRIPTION
This PR adds the endpoint for `POST /api/sessions` which will link log a registered `Player` in via an email address and password so they can play the game.

This also fixes a bug where a `Player` could not be updated because of the validation order of the `password` and `crypted_password` fields.

Closes [Login Endpoint](https://trello.com/c/7EkLtvts/9-login-endpoint)