### PR TITLE
Move to Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,57 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/ruby
+        environment:
+          RAILS_ENV: test
+          PGHOST: 127.0.0.1
+          PGUSER: circleci
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      - image: circleci/postgres:9.6-alpine
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_DB: gotcha-api_test
+          POSTGRES_PASSWORD: ""
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+
+      - run:
+          name: Wait for DB
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+
+      # Database setup
+      - run: bundle exec rake db:create
+
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            bundle exec rspec --format progress

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/ruby
+      - image: circleci/ruby:2.4.1-node
         environment:
           RAILS_ENV: test
           PGHOST: 127.0.0.1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Gotcha API
 ============
 
-[ ![Codeship Status for jwright/gotcha-api](https://codeship.com/projects/693f2a80-ef8c-0135-710d-42bca7cc3fec/status?branch=master)](https://codeship.com/projects/271134)
+[![CircleCI](https://circleci.com/gh/jwright/gotcha-api.svg?style=svg)](https://circleci.com/gh/jwright/gotcha-api)
 
 Gotcha where I want 'cha
 


### PR DESCRIPTION
This PR adds the configuration and badge status to move the repo to [CircleCI](http://circleci.com) instead of [Codeship](http://codeship) since CircleCI is free (and faster).