### PR TITLE
Register device endpoint

### DIFF
--- a/app/controllers/api/devices_controller.rb
+++ b/app/controllers/api/devices_controller.rb
@@ -1,4 +1,6 @@
 class API::DevicesController < ApplicationController
+  before_action :require_authorization
+
   def create
     device = Device.create! device_params.merge(player_id: current_user.id,
                                                 registered_at: DateTime.now)

--- a/app/controllers/api/devices_controller.rb
+++ b/app/controllers/api/devices_controller.rb
@@ -1,0 +1,5 @@
+class API::DevicesController < ApplicationController
+  def create
+    head :created
+  end
+end

--- a/app/controllers/api/devices_controller.rb
+++ b/app/controllers/api/devices_controller.rb
@@ -1,9 +1,9 @@
 class API::DevicesController < ApplicationController
   def create
-    Device.create! device_params.merge(player_id: current_user.id,
-                                       registered_at: DateTime.now)
+    device = Device.create! device_params.merge(player_id: current_user.id,
+                                                registered_at: DateTime.now)
 
-    head :created
+    render json: DeviceSerializer.new(device).serialized_json, status: :created
   end
 
   private

--- a/app/controllers/api/devices_controller.rb
+++ b/app/controllers/api/devices_controller.rb
@@ -1,5 +1,16 @@
 class API::DevicesController < ApplicationController
   def create
+    Device.create! device_params.merge(player_id: current_user.id,
+                                       registered_at: DateTime.now)
+
     head :created
+  end
+
+  private
+
+  def device_params
+    params.require(:data)
+          .require(:attributes)
+          .permit(:token)
   end
 end

--- a/app/documentation/devices.rb
+++ b/app/documentation/devices.rb
@@ -1,0 +1,128 @@
+module Documentation
+  module Devices
+    def self.included(base)
+      base.class_eval do
+
+        swagger_path "/devices" do
+          operation :post do
+            key :summary, "Registers a device"
+            key :description, "Registers a device so it can retrieve notifications "\
+                              "when a match is created."
+            key :tags, ["DEVICES"]
+            security do
+              key :Bearer, []
+            end
+            parameter do
+              key :name, :attributes
+              key :type, :object
+              key :in, :body
+              key :description, "The device information to register"
+              schema do
+                key :"$ref", :DeviceInput
+              end
+            end
+            response 201 do
+              key :description, "A JSON API formatted representation of a single Device"
+              schema do
+                key :"$ref", :Device
+              end
+              example name: JSONAPI::MEDIA_TYPE do
+                key :data, [{
+                  id: "12345",
+                  type: "device",
+                  attributes: {
+                    registered_at: 12345556565,
+                    token: "DEVICE_0001"
+                  },
+                  relationships: {
+                    player: {
+                      data: {
+                        type: "player",
+                        id: "12345"
+                      }
+                    }
+                  }
+                }]
+              end
+            end
+            response 401 do
+              key :description, "Unauthorized"
+              schema do
+                key :type, :string
+              end
+              example name: JSONAPI::MEDIA_TYPE do
+                key :errors, "Unauthorized"
+              end
+            end
+          end
+        end
+
+        swagger_schema :Device do
+          key :type, :object
+          key :required, [:id,
+                          :type,
+                          :token]
+          property :data do
+            key :type, :object
+            property :id do
+              key :type, :string
+              key :format, :int64
+              key :description, "Unique identifier for the object"
+            end
+            property :type do
+              key :type, :string
+              key :description, "The type of object that is represented"
+              key :enum, ["device"]
+            end
+            property :attributes do
+              key :type, :object
+              property :registered_at do
+                key :type, :integer
+                key :format, :dateTime
+                key :description, "The date/time of when the device was registered"
+              end
+              property :token do
+                key :type, :string
+                key :description, "The token of the device that was registered"
+              end
+            end
+            property :relationships do
+              key :type, :object
+              property :data do
+                key :type, :object
+                property :id do
+                  key :type, :string
+                  key :format, :int64
+                  key :description, "Unique identifier for the object"
+                end
+                property :type do
+                  key :type, :string
+                  key :description, "The type of object that is represented"
+                  key :enum, ["player"]
+                end
+              end
+            end
+          end
+        end
+
+        swagger_schema :DeviceInput do
+          key :type, :object
+          key :required, [:data]
+          property :data do
+            key :type, :object
+            key :required, [:attributes]
+            property :attributes do
+              key :type, :object
+              key :required, [:token]
+              property :token do
+                key :type, :string
+                key :description, "The token of the device to register"
+              end
+            end
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/app/documentation/root.rb
+++ b/app/documentation/root.rb
@@ -1,6 +1,7 @@
 require "jsonapi"
 require "swagger/blocks"
 require_relative "arenas"
+require_relative "devices"
 require_relative "players"
 require_relative "sessions"
 
@@ -9,6 +10,7 @@ module Documentation
     def self.included(base)
       base.send :include, Swagger::Blocks
       base.send :include, Arenas
+      base.send :include, Devices
       base.send :include, Players
       base.send :include, Sessions
 
@@ -41,6 +43,9 @@ module Documentation
           end
           tag name: "ARENAS" do
             key :description, "Arena operations"
+          end
+          tag name: "DEVICES" do
+            key :description, "Device operations"
           end
           tag name: "PLAYERS" do
             key :description, "Player operations"

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,0 +1,6 @@
+class Device < ApplicationRecord
+  belongs_to :player
+
+  validates :token, presence: true,
+                    uniqueness: { message: "has already been registered" }
+end

--- a/app/serializers/device_serializer.rb
+++ b/app/serializers/device_serializer.rb
@@ -1,0 +1,9 @@
+require "fast_jsonapi"
+
+class DeviceSerializer
+  include FastJsonapi::ObjectSerializer
+
+  set_type :device
+  attributes :registered_at, :token
+  belongs_to :player
+end

--- a/app/serializers/device_serializer.rb
+++ b/app/serializers/device_serializer.rb
@@ -6,4 +6,17 @@ class DeviceSerializer
   set_type :device
   attributes :registered_at, :token
   belongs_to :player
+
+  def initialize(resource, options={})
+    super
+    @record = DeviceDecorator.new(@record)
+  end
+
+  private
+
+  class DeviceDecorator < SimpleDelegator
+    def registered_at
+      __getobj__.registered_at.to_i
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     resources :arenas, only: :index do
       post :play, on: :member
     end
+    resources :devices, only: :create
     resources :players, only: :create
     resources :sessions, only: :create
   end

--- a/db/migrate/20180319230523_create_devices.rb
+++ b/db/migrate/20180319230523_create_devices.rb
@@ -1,0 +1,11 @@
+class CreateDevices < ActiveRecord::Migration[5.1]
+  def change
+    create_table :devices do |t|
+      t.references :player, foreign_key: true
+      t.string :token
+      t.datetime :registered_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180219164434) do
+ActiveRecord::Schema.define(version: 20180319230523) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,15 @@ ActiveRecord::Schema.define(version: 20180219164434) do
     t.float "longitude"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "devices", force: :cascade do |t|
+    t.bigint "player_id"
+    t.string "token"
+    t.datetime "registered_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["player_id"], name: "index_devices_on_player_id"
   end
 
   create_table "player_arenas", force: :cascade do |t|
@@ -49,6 +58,7 @@ ActiveRecord::Schema.define(version: 20180219164434) do
     t.string "name", null: false
   end
 
+  add_foreign_key "devices", "players"
   add_foreign_key "player_arenas", "arenas"
   add_foreign_key "player_arenas", "players"
 end

--- a/spec/factories/device_factory.rb
+++ b/spec/factories/device_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :device do
+    player
+    sequence(:token) { |n| "DEVICE_#{n.to_s.rjust(3, "0")}" }
+    registered_at { DateTime.now }
+  end
+end

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Device do
+  describe "validations" do
+    subject { build :device }
+
+    it "requires a token to be present" do
+      subject.token = nil
+
+      expect(subject).to_not be_valid
+      expect(subject.errors[:token]).to include "can't be blank"
+    end
+
+    it "requires the token to be unique" do
+      create :device, token: subject.token
+
+      expect(subject).to_not be_valid
+      expect(subject.errors[:token]).to include "has already been registered"
+    end
+  end
+end

--- a/spec/requests/register_device_spec.rb
+++ b/spec/requests/register_device_spec.rb
@@ -1,0 +1,24 @@
+require "request_helper"
+
+RSpec.describe "POST /api/devices" do
+  let(:player) { create :player, :authorized }
+  let(:token) { "DEVICE_001" }
+  let(:valid_parameters) do
+    {
+      data: {
+        type: "device",
+        attributes: {
+          token: token
+        }
+      }
+    }.to_json
+  end
+
+  context "with a valid request" do
+    it "returns a created status" do
+      post "/api/devices", params: valid_parameters, headers: valid_authed_headers
+
+      expect(response).to be_created
+    end
+  end
+end

--- a/spec/requests/register_device_spec.rb
+++ b/spec/requests/register_device_spec.rb
@@ -15,10 +15,19 @@ RSpec.describe "POST /api/devices" do
   end
 
   context "with a valid request" do
+    let(:device) { Device.unscoped.last }
+
     it "returns a created status" do
       post "/api/devices", params: valid_parameters, headers: valid_authed_headers
 
       expect(response).to be_created
+    end
+
+    it "creates the device" do
+      expect { post "/api/devices", params: valid_parameters,
+                                    headers: valid_authed_headers }.to \
+        change { Device.count }.by 1
+      expect(device.token).to eq token
     end
   end
 end

--- a/spec/requests/register_device_spec.rb
+++ b/spec/requests/register_device_spec.rb
@@ -29,5 +29,18 @@ RSpec.describe "POST /api/devices" do
         change { Device.count }.by 1
       expect(device.token).to eq token
     end
+
+    it "associates the device with the current player" do
+      post "/api/devices", params: valid_parameters, headers: valid_authed_headers
+
+      expect(device.player).to eq player
+    end
+
+    it "returns a json representation of a device" do
+      post "/api/devices", params: valid_parameters, headers: valid_authed_headers
+
+      expect(json_response[:data][:type]).to eq "device"
+      expect(json_response[:data][:id]).to eq device.id.to_s
+    end
   end
 end

--- a/spec/serializers/device_serializer_spec.rb
+++ b/spec/serializers/device_serializer_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe DeviceSerializer do
+  let(:device) { create :device }
+
+  subject { described_class.new(device) }
+
+  describe "#serializable_hash" do
+    let(:hash) { subject.serializable_hash[:data] }
+
+    it "serializes the type" do
+      expect(hash[:type]).to eq :device
+    end
+
+    it "serializes the id" do
+      expect(hash[:id]).to eq device.id.to_s
+    end
+
+    it "serializes the attributes" do
+      expect(hash[:attributes].keys).to \
+        match_array [:registered_at, :token]
+      expect(hash[:attributes][:token]).to eq device.token
+    end
+
+    it "serializes the relationships" do
+      expect(hash[:relationships].keys).to match_array [:player]
+      expect(hash[:relationships][:player][:data][:id]).to \
+        eq device.player_id.to_s
+    end
+  end
+end

--- a/spec/serializers/device_serializer_spec.rb
+++ b/spec/serializers/device_serializer_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe DeviceSerializer do
       expect(hash[:attributes].keys).to \
         match_array [:registered_at, :token]
       expect(hash[:attributes][:token]).to eq device.token
+      expect(hash[:attributes][:registered_at]).to be_a Integer
     end
 
     it "serializes the relationships" do


### PR DESCRIPTION
This PR adds the endpoint for `POST /api/devices` which will link a `Player` with a `Device` so that it can receive new match notifications.

Closes [Register Device Endpoint](https://trello.com/c/n7DLBOX3/16-register-device-endpoint)