### PR TITLE
Unregister device endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,23 @@ bundle exec rails g migration <migration_name> <options>
 
 ## DEPLOYMENT
 
+This project is deployed to [Heroku](http://heroku.com) and it can be deployed via git.
+
+```
+git remote add staging https://git.heroku.com/gotcha-api-staging.git
+git push staging master
+```
+
+## IMPROVEMENTS
+
+This project can be improved in a multiple of ways. These were not implemented as it would complicate the workshop.
+
+### Authorization
+
+The API endpoints do not ensure that the current `Player` can implement the actions. For example, the `DELETE /api/devices/:id` endpoint does not check to ensure that only the player who was assigned the device can delete it.
+
+Usually I use [CanCan](https://github.com/CanCanCommunity/cancancan) to ensure the authorization of the endpoint is appropriate.
+
 ## CONTRIBUTING
 
 1. Clone the repository `git clone https://github.com/jwright/gotcha-api`

--- a/app/controllers/api/devices_controller.rb
+++ b/app/controllers/api/devices_controller.rb
@@ -8,6 +8,10 @@ class API::DevicesController < ApplicationController
     render json: DeviceSerializer.new(device).serialized_json, status: :created
   end
 
+  def destroy
+    head :no_content
+  end
+
   private
 
   def device_params

--- a/app/controllers/api/devices_controller.rb
+++ b/app/controllers/api/devices_controller.rb
@@ -9,6 +9,9 @@ class API::DevicesController < ApplicationController
   end
 
   def destroy
+    device = Device.find_by_token! params[:id]
+    device.destroy
+
     head :no_content
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,7 +66,7 @@ class ApplicationController < ActionController::API
     # This is needed because Rails returns a :bad_request (400) instead
     # of a :unsupported_media_type (415) for invalid content-type headers
     # There is a PR to fix this: https://github.com/rails/rails/pull/26632
-    if request.post? || request.put? || request.patch?
+    if request.post? || request.put? || request.patch? || request.delete?
       unless request.content_type == JSONAPI::MEDIA_TYPE
         raise JSONAPI::UnsupportedMediaTypeError.new(request.content_type)
       end

--- a/app/documentation/devices.rb
+++ b/app/documentation/devices.rb
@@ -55,6 +55,44 @@ module Documentation
               end
             end
           end
+
+          operation :delete do
+            key :summary, "Unregisters a device"
+            key :description, "Unregisters a device so it can no longer receive "\
+                              "notifications"
+            key :tags, ["DEVICES"]
+            security do
+              key :Bearer, []
+            end
+            parameter do
+              key :name, :token
+              key :type, :string
+              key :in, :query
+              key :description, "The device token that should be unregistered"
+              key :required, true
+            end
+            response 204 do
+              key :description, "No content"
+            end
+            response 401 do
+              key :description, "Unauthorized"
+              schema do
+                key :type, :string
+              end
+              example name: JSONAPI::MEDIA_TYPE do
+                key :errors, "Unauthorized"
+              end
+            end
+            response 404 do
+              key :description, "Not found"
+              schema do
+                key :type, :string
+              end
+              example name: JSONAPI::MEDIA_TYPE do
+                key :errors, "Not found"
+              end
+            end
+          end
         end
 
         swagger_schema :Device do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     resources :arenas, only: :index do
       post :play, on: :member
     end
-    resources :devices, only: :create
+    resources :devices, only: [:create, :destroy]
     resources :players, only: :create
     resources :sessions, only: :create
   end

--- a/spec/requests/unregister_device_spec.rb
+++ b/spec/requests/unregister_device_spec.rb
@@ -26,4 +26,20 @@ RSpec.describe "DELETE /api/devices/:token" do
       expect(response).to be_not_found
     end
   end
+
+  it_behaves_like "an authenticated request" do
+    let(:make_request) do
+      -> (headers) do
+        delete "/api/devices/#{token}", headers: valid_headers.merge(headers)
+      end
+    end
+  end
+
+  it_behaves_like "a request responding to correct headers" do
+    let(:make_request) do
+      -> (headers) do
+        delete "/api/devices/#{token}", headers: valid_authed_headers.merge(headers)
+      end
+    end
+  end
 end

--- a/spec/requests/unregister_device_spec.rb
+++ b/spec/requests/unregister_device_spec.rb
@@ -1,0 +1,15 @@
+require "request_helper"
+
+RSpec.describe "DELETE /api/devices/:token" do
+  let(:device) { create :device, player: player, token: token }
+  let(:player) { create :player, :authorized }
+  let(:token) { "DEVICE_001" }
+
+  context "with a valid request" do
+    it "returns a no content status" do
+      delete "/api/devices/#{token}", headers: valid_authed_headers
+
+      expect(response).to be_no_content
+    end
+  end
+end

--- a/spec/requests/unregister_device_spec.rb
+++ b/spec/requests/unregister_device_spec.rb
@@ -1,7 +1,7 @@
 require "request_helper"
 
 RSpec.describe "DELETE /api/devices/:token" do
-  let(:device) { create :device, player: player, token: token }
+  let!(:device) { create :device, player: player, token: token }
   let(:player) { create :player, :authorized }
   let(:token) { "DEVICE_001" }
 
@@ -10,6 +10,20 @@ RSpec.describe "DELETE /api/devices/:token" do
       delete "/api/devices/#{token}", headers: valid_authed_headers
 
       expect(response).to be_no_content
+    end
+
+    it "deletes the device" do
+      expect { delete "/api/devices/#{token}", headers: valid_authed_headers }.to \
+        change { Device.count }.by -1
+      expect(Device.find_by_token(token)).to be_nil
+    end
+  end
+
+  context "with a device id that does not exist" do
+    it "returns a not found status" do
+      delete "/api/devices/blah", headers: valid_authed_headers
+
+      expect(response).to be_not_found
     end
   end
 end


### PR DESCRIPTION
This PR adds the endpoint for `DELETE /api/devices/:id` which will unlink a `Player` from a `Device` so that it no longer receives new match notifications.

Closes [Unregister Device Endpoint](https://trello.com/c/PiAp0jTO/17-unregister-device-endpoint)