### PR TITLE
Logout endpoint

### DIFF
--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -1,4 +1,6 @@
 class API::SessionsController < ApplicationController
+  before_action :require_authorization, only: :destroy
+
   def create
     player = Player.authenticate(player_params[:email_address],
                                  player_params[:password])

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -12,6 +12,12 @@ class API::SessionsController < ApplicationController
     end
   end
 
+  def destroy
+    current_user.update_attributes! api_key: nil
+
+    head :no_content
+  end
+
   private
 
   def player_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
     end
     resources :devices, only: [:create, :destroy]
     resources :players, only: :create
-    resources :sessions, only: :create
+    resources :sessions, only: :create do
+      delete :destroy, on: :collection
+    end
   end
 
   resources :docs, path: "/api/docs", only: :index

--- a/spec/requests/logout_spec.rb
+++ b/spec/requests/logout_spec.rb
@@ -1,0 +1,23 @@
+require "request_helper"
+
+RSpec.describe "DELETE /api/sessions" do
+  let!(:player) { create :player, :authorized }
+
+  context "with a valid request" do
+    it "returns a no content status" do
+      delete "/api/sessions", headers: valid_authed_headers
+
+      expect(response).to be_no_content
+    end
+
+    it "removes the api key for the player" do
+      delete "/api/sessions", headers: valid_authed_headers
+
+      expect(player.reload.api_key).to be_nil
+    end
+  end
+
+  context "without an API key" do
+    xit "returns a not authorized status"
+  end
+end

--- a/spec/requests/logout_spec.rb
+++ b/spec/requests/logout_spec.rb
@@ -17,7 +17,11 @@ RSpec.describe "DELETE /api/sessions" do
     end
   end
 
-  context "without an API key" do
-    xit "returns a not authorized status"
+  it_behaves_like "an authenticated request" do
+    let(:make_request) do
+      -> (headers) do
+        delete "/api/sessions", headers: valid_authed_headers.merge(headers)
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds the endpoint `DELETE /api/sessions` which logs the `Player` out of the API by removing their `api_key`. This will require the `Player` to re-login to the application in order to play again!