### PR TITLE
Request new match

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "rack-cors"
 
 gem "bcrypt"
 gem "carrierwave-base64"
+gem "cancancan"
 gem "fast_jsonapi"
 gem "fog-aws"
 gem "houston"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
     bcrypt (3.1.11)
     builder (3.2.3)
     byebug (10.0.0)
+    cancancan (1.16.0)
     carrierwave (1.2.2)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
@@ -217,6 +218,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt
   byebug
+  cancancan
   carrierwave-base64
   dotenv-rails
   factory_bot_rails

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -1,5 +1,16 @@
 class API::MatchesController < ApplicationController
   def create
+    arena = Arena.find match_params[:arena_id]
+    MatchMaker.match! player: current_user, arena: arena
+
     head :created
+  end
+
+  private
+
+  def match_params
+    params.require(:data)
+          .require(:attributes)
+          .permit(:arena_id)
   end
 end

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -1,9 +1,10 @@
 class API::MatchesController < ApplicationController
   def create
     arena = Arena.find match_params[:arena_id]
-    MatchMaker.match! player: current_user, arena: arena
+    match = MatchMaker.match! player: current_user, arena: arena
 
-    head :created
+    render json: MatchSerializer.new(match).serialized_json,
+           status: :created
   end
 
   private

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -1,4 +1,6 @@
 class API::MatchesController < ApplicationController
+  before_action :require_authorization
+
   def create
     arena = Arena.find match_params[:arena_id]
     match = MatchMaker.match! player: current_user, arena: arena

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -3,6 +3,7 @@ class API::MatchesController < ApplicationController
 
   def create
     arena = Arena.find match_params[:arena_id]
+    authorize! :read, arena, message: "Not authorized to play in that Arena"
     match = MatchMaker.match! player: current_user, arena: arena
 
     if match

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -1,0 +1,5 @@
+class API::MatchesController < ApplicationController
+  def create
+    head :created
+  end
+end

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -3,8 +3,10 @@ class API::MatchesController < ApplicationController
     arena = Arena.find match_params[:arena_id]
     match = MatchMaker.match! player: current_user, arena: arena
 
-    render json: MatchSerializer.new(match).serialized_json,
-           status: :created
+    if match
+      render json: MatchSerializer.new(match).serialized_json,
+             status: :created
+    end
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 require_relative "../documentation/root"
 
 class ApplicationController < ActionController::API
+  include CanCan::ControllerAdditions
   include Documentation::Root
 
   attr_reader :current_user
@@ -21,6 +22,10 @@ class ApplicationController < ActionController::API
 
   rescue_from ActionController::ParameterMissing do |exception|
     render_errors exception.message
+  end
+
+  rescue_from CanCan::AccessDenied do |exception|
+    render_errors exception.message, :unauthorized
   end
 
   rescue_from JSONAPI::NotAcceptableError do |exception|

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -3,6 +3,10 @@ class Ability
 
   def initialize(player)
     if player.present?
+      can :read, Arena do |arena|
+        arena.playable_by?(player)
+      end
+
       can [:create, :read, :update], Match do |match|
         match.arena && match.arena.playable_by?(player)
       end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -3,7 +3,7 @@ class Ability
 
   def initialize(player)
     if player.present?
-      can :manage, Match do |match|
+      can [:create, :read, :update], Match do |match|
         match.arena && match.arena.playable_by?(player)
       end
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,11 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(player)
+    if player.present?
+      can :manage, Match do |match|
+        match.arena && match.arena.playable_by?(player)
+      end
+    end
+  end
+end

--- a/app/models/arena.rb
+++ b/app/models/arena.rb
@@ -12,6 +12,10 @@ class Arena < ApplicationRecord
       .join(", ")
   end
 
+  def playable_by?(player)
+    players.include?(player)
+  end
+
   private
 
   def address_changed?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
       post :play, on: :member
     end
     resources :devices, only: [:create, :destroy]
+    resources :matches, only: :create
     resources :players, only: :create
     resources :sessions, only: :create do
       delete :destroy, on: :collection

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+require "cancan/matchers"
+
+RSpec.describe Ability do
+  let(:player) { create :player, :authorized }
+
+  subject { described_class.new(player) }
+
+  context "for a match" do
+    let(:match) { create :match }
+
+    it "can manage a match in an arena the player is playing in" do
+      player.arenas << match.arena
+
+      expect(subject).to be_able_to :manage, match
+    end
+
+    it "can create a match" do
+      expect(subject).to be_able_to :create, Match
+    end
+
+    it "cannot read a match in another arena" do
+      expect(subject).to_not be_able_to :read, match
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Ability do
 
   subject { described_class.new(player) }
 
-  xcontext "for an arena" do
+  context "for an arena" do
     let(:arena) { create :arena }
 
     it "can read an arena the player is playing in" do
@@ -15,10 +15,25 @@ RSpec.describe Ability do
       expect(subject).to be_able_to :read, arena
     end
 
-    xit "cannot read an arena the player is not playing in"
-    xit "cannot create an arena"
-    xit "cannot update an arena"
-    xit "cannot delete an arena"
+    it "cannot read an arena the player is not playing in" do
+      expect(subject).to_not be_able_to :read, arena
+    end
+
+    it "cannot create an arena" do
+      expect(subject).to_not be_able_to :create, Arena
+    end
+
+    it "cannot update an arena" do
+      player.arenas << arena
+
+      expect(subject).to_not be_able_to :update, arena
+    end
+
+    it "cannot delete an arena" do
+      player.arenas << arena
+
+      expect(subject).to_not be_able_to :delete, arena
+    end
   end
 
   context "for a match" do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -6,13 +6,35 @@ RSpec.describe Ability do
 
   subject { described_class.new(player) }
 
+  xcontext "for an arena" do
+    let(:arena) { create :arena }
+
+    it "can read an arena the player is playing in" do
+      player.arenas << arena
+
+      expect(subject).to be_able_to :read, arena
+    end
+
+    xit "cannot read an arena the player is not playing in"
+    xit "cannot create an arena"
+    xit "cannot update an arena"
+    xit "cannot delete an arena"
+  end
+
   context "for a match" do
     let(:match) { create :match }
 
-    it "can manage a match in an arena the player is playing in" do
+    it "can read or update a match in an arena the player is playing in" do
       player.arenas << match.arena
 
-      expect(subject).to be_able_to :manage, match
+      expect(subject).to be_able_to :read, match
+      expect(subject).to be_able_to :update, match
+    end
+
+    it "cannot delete a match in an arena the player is playing in" do
+      player.arenas << match.arena
+
+      expect(subject).to_not be_able_to :delete, match
     end
 
     it "can create a match" do

--- a/spec/models/arena_spec.rb
+++ b/spec/models/arena_spec.rb
@@ -40,4 +40,19 @@ RSpec.describe Arena do
         eq "123 Main St., Beverly Hills, CA, 90210"
     end
   end
+
+  describe "#playable_by?" do
+    let(:player) { create :player }
+    subject { create :arena }
+
+    it "returns true if the player is playing in the arena" do
+      player.arenas << subject
+
+      expect(subject).to be_playable_by player
+    end
+
+    it "returns false if the player is not playing in the arena" do
+      expect(subject).to_not be_playable_by player
+    end
+  end
 end

--- a/spec/requests/request_new_match_spec.rb
+++ b/spec/requests/request_new_match_spec.rb
@@ -80,4 +80,22 @@ RSpec.describe "POST /api/matches" do
       expect(json_response[:errors]).to include "Arena with id -1 not found"
     end
   end
+
+  it_behaves_like "an authenticated request" do
+    let(:make_request) do
+      -> (headers) do
+        post "/api/matches", params: valid_parameters,
+                             headers: valid_headers.merge(headers)
+      end
+    end
+  end
+
+  it_behaves_like "a request responding to correct headers" do
+    let(:make_request) do
+      -> (headers) do
+        post "/api/matches", params: valid_parameters,
+                             headers: valid_headers.merge(headers)
+      end
+    end
+  end
 end

--- a/spec/requests/request_new_match_spec.rb
+++ b/spec/requests/request_new_match_spec.rb
@@ -1,0 +1,24 @@
+require "request_helper"
+
+RSpec.describe "POST /api/matches" do
+  let(:arena) { create :arena }
+  let(:player) { create :player, :authorized, arenas: [arena] }
+  let(:valid_parameters) do
+    {
+      data: {
+        type: "match",
+        attributes: {
+          arena_id: arena.id
+        }
+      }
+    }.to_json
+  end
+
+  context "with a valid request" do
+    it "returns a created status" do
+      post "/api/matches", params: valid_parameters, headers: valid_authed_headers
+
+      expect(response).to be_created
+    end
+  end
+end

--- a/spec/requests/request_new_match_spec.rb
+++ b/spec/requests/request_new_match_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe "POST /api/matches" do
         expect(match.seeker).to eq player
         expect(match.opponent).to eq opponent
       end
+
+      it "returns the json representation of the match" do
+        post "/api/matches", params: valid_parameters, headers: valid_authed_headers
+
+        expect(json_response[:data][:type]).to eq "match"
+        expect(json_response[:data][:id]).to eq match.id.to_s
+      end
     end
   end
 end

--- a/spec/requests/request_new_match_spec.rb
+++ b/spec/requests/request_new_match_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe "POST /api/matches" do
       end
 
       it "creates a match between the two players" do
-        post "/api/matches", params: valid_parameters, headers: valid_authed_headers
+        expect { post "/api/matches", params: valid_parameters,
+                                      headers: valid_authed_headers }.to \
+          change { Match.count }.by 1
 
         expect(match.arena).to eq arena
         expect(match.seeker).to eq player
@@ -38,6 +40,20 @@ RSpec.describe "POST /api/matches" do
 
         expect(json_response[:data][:type]).to eq "match"
         expect(json_response[:data][:id]).to eq match.id.to_s
+      end
+    end
+
+    context "without an available opponent" do
+      it "returns a no content status" do
+        post "/api/matches", params: valid_parameters, headers: valid_authed_headers
+
+        expect(response).to be_no_content
+      end
+
+      it "does not create a match" do
+        expect { post "/api/matches", params: valid_parameters,
+                                      headers: valid_authed_headers }.to_not \
+          change { Match.count }
       end
     end
   end

--- a/spec/requests/request_new_match_spec.rb
+++ b/spec/requests/request_new_match_spec.rb
@@ -59,6 +59,24 @@ RSpec.describe "POST /api/matches" do
   end
 
   context "with an arena that the player is not playing in" do
+    let(:another_arena) { create :arena }
+    let(:parameters) do
+      {
+        data: {
+          type: "match",
+          attributes: {
+            arena_id: another_arena.id
+          }
+        }
+      }.to_json
+    end
+
+    it "returns a not authorized status" do
+      post "/api/matches", params: parameters, headers: valid_authed_headers
+
+      expect(response).to be_unauthorized
+      expect(json_response[:errors]).to include "Not authorized to play in that Arena"
+    end
   end
 
   context "without an arena" do

--- a/spec/requests/request_new_match_spec.rb
+++ b/spec/requests/request_new_match_spec.rb
@@ -15,10 +15,23 @@ RSpec.describe "POST /api/matches" do
   end
 
   context "with a valid request" do
-    it "returns a created status" do
-      post "/api/matches", params: valid_parameters, headers: valid_authed_headers
+    context "with an available opponent" do
+      let(:match) { Match.unscoped.last }
+      let!(:opponent) { create :player, arenas: [arena] }
 
-      expect(response).to be_created
+      it "returns a created status" do
+        post "/api/matches", params: valid_parameters, headers: valid_authed_headers
+
+        expect(response).to be_created
+      end
+
+      it "creates a match between the two players" do
+        post "/api/matches", params: valid_parameters, headers: valid_authed_headers
+
+        expect(match.arena).to eq arena
+        expect(match.seeker).to eq player
+        expect(match.opponent).to eq opponent
+      end
     end
   end
 end

--- a/spec/requests/request_new_match_spec.rb
+++ b/spec/requests/request_new_match_spec.rb
@@ -57,4 +57,27 @@ RSpec.describe "POST /api/matches" do
       end
     end
   end
+
+  context "with an arena that the player is not playing in" do
+  end
+
+  context "without an arena" do
+    let(:parameters) do
+      {
+        data: {
+          type: "match",
+          attributes: {
+            arena_id: -1
+          }
+        }
+      }.to_json
+    end
+
+    it "returns a not found status" do
+      post "/api/matches", params: parameters, headers: valid_authed_headers
+
+      expect(response).to be_not_found
+      expect(json_response[:errors]).to include "Arena with id -1 not found"
+    end
+  end
 end


### PR DESCRIPTION
Adds an endpoint to create a new `Match` for a `Player`. This is used when a `Player` wants a new match because their existing match is not what they had hoped.

This also introduces [CanCan](https://github.com/CanCanCommunity/cancancan) in order to authorize that the `Player` can request a new `Match` for a specific `Arena`.