### PR TITLE
Capture player

### DIFF
--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -1,6 +1,10 @@
 class API::MatchesController < ApplicationController
   before_action :require_authorization
 
+  def capture
+    head :ok
+  end
+
   def create
     arena = Arena.find match_params[:arena_id]
     authorize! :read, arena, message: "Not authorized to play in that Arena"

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -2,6 +2,9 @@ class API::MatchesController < ApplicationController
   before_action :require_authorization
 
   def capture
+    match = Match.find params[:id]
+    match.found!
+
     head :ok
   end
 

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -3,6 +3,7 @@ class API::MatchesController < ApplicationController
 
   def capture
     match = Match.find params[:id]
+    authorize! :update, match, message: "Not authorized to play in that Match"
     match.found!
 
     render json: MatchSerializer.new(match).serialized_json

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -5,7 +5,7 @@ class API::MatchesController < ApplicationController
     match = Match.find params[:id]
     match.found!
 
-    head :ok
+    render json: MatchSerializer.new(match).serialized_json
   end
 
   def create

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -7,6 +7,7 @@ class API::MatchesController < ApplicationController
     match.found!
 
     MakeMatchJob.perform_later match.seeker_id, match.arena_id
+    MakeMatchJob.perform_later match.opponent_id, match.arena_id
 
     render json: MatchSerializer.new(match).serialized_json
   end

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -6,6 +6,8 @@ class API::MatchesController < ApplicationController
     authorize! :update, match, message: "Not authorized to play in that Match"
     match.found!
 
+    MakeMatchJob.perform_later match.seeker_id, match.arena_id
+
     render json: MatchSerializer.new(match).serialized_json
   end
 

--- a/app/documentation/matches.rb
+++ b/app/documentation/matches.rb
@@ -1,0 +1,147 @@
+module Documentation
+  module Matches
+    def self.included(base)
+      base.class_eval do
+
+        swagger_path "/matches/:id/capture" do
+          operation :post do
+            key :summary, "Mark the match as found between the seeker and the opponent"
+            key :description, "Marks the match as found and starts new matches "\
+                              "for both the seeker and the opponent."
+            key :tags, ["MATCHES"]
+            security do
+              key :Bearer, []
+            end
+            response 200 do
+              key :description, "A JSON API formatted representation of the single Match that was found."
+              schema do
+                key :"$ref", :Match
+              end
+              example name: JSONAPI::MEDIA_TYPE do
+                key :data, {
+                  id: "12345",
+                  type: "match",
+                  attributes: {
+                    found_at: 5632493294,
+                    matched_at: 783287834764,
+                  },
+                  relationships: {
+                    arena: {
+                      data: {
+                        id: "67893",
+                        type: "arena"
+                      }
+                    },
+                    opponent: {
+                      data: {
+                        id: "53273",
+                        type: "player"
+                      }
+                    },
+                    seeker: {
+                      data: {
+                        id: "77349543",
+                        type: "player"
+                      }
+                    }
+                  }
+                }
+              end
+            end
+            response 401 do
+              key :description, "Unauthorized"
+              schema do
+                key :type, :string
+              end
+              example name: JSONAPI::MEDIA_TYPE do
+                key :errors, "Unauthorized"
+              end
+            end
+          end
+        end
+
+        swagger_schema :Match do
+          key :type, :object
+          key :required, [:id,
+                          :type,
+                          :matched_at]
+          property :data do
+            key :type, :object
+            property :id do
+              key :type, :string
+              key :format, :int64
+              key :description, "Unique identifier for the object"
+            end
+            property :type do
+              key :type, :string
+              key :description, "The type of object that is represented"
+              key :enum, ["match"]
+            end
+            property :attributes do
+              key :type, :object
+              property :found_at do
+                key :type, :integer
+                key :format, :dateTime
+                key :description, "The date/time of when the player was found in "\
+                                  "the match in the number of seconds since the Epoch"
+              end
+              property :matched_at do
+                key :type, :integer
+                key :format, :dateTime
+                key :description, "The date/time of when the player was placed in "\
+                                  "the match in the number of seconds since the Epoch"
+              end
+            end
+            property :relationships do
+              key :type, :object
+              property :data do
+                key :type, :object
+                property :arena do
+                  key :type, :object
+                  property :id do
+                    key :type, :string
+                    key :format, :int64
+                    key :description, "Unique identifier for the object"
+                  end
+                  property :type do
+                    key :type, :string
+                    key :description, "The type of object that is represented"
+                    key :enum, ["arena"]
+                  end
+                end
+                property :opponent do
+                  key :type, :object
+                  property :id do
+                    key :type, :string
+                    key :format, :int64
+                    key :description, "Unique identifier for the object"
+                  end
+                  property :type do
+                    key :type, :string
+                    key :description, "The type of object that is represented"
+                    key :enum, ["player"]
+                  end
+                end
+                property :seeker do
+                  key :type, :object
+                  property :id do
+                    key :type, :string
+                    key :format, :int64
+                    key :description, "Unique identifier for the object"
+                  end
+                  property :type do
+                    key :type, :string
+                    key :description, "The type of object that is represented"
+                    key :enum, ["player"]
+                  end
+                end
+              end
+            end
+
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/app/documentation/root.rb
+++ b/app/documentation/root.rb
@@ -2,6 +2,7 @@ require "jsonapi"
 require "swagger/blocks"
 require_relative "arenas"
 require_relative "devices"
+require_relative "matches"
 require_relative "players"
 require_relative "sessions"
 
@@ -11,6 +12,7 @@ module Documentation
       base.send :include, Swagger::Blocks
       base.send :include, Arenas
       base.send :include, Devices
+      base.send :include, Matches
       base.send :include, Players
       base.send :include, Sessions
 
@@ -46,6 +48,9 @@ module Documentation
           end
           tag name: "DEVICES" do
             key :description, "Device operations"
+          end
+          tag name: "MATCHES" do
+            key :description, "Match operations"
           end
           tag name: "PLAYERS" do
             key :description, "Player operations"

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -20,7 +20,7 @@ class Match < ApplicationRecord
   end
 
   def found!
-    update_attributes found_at: DateTime.now
+    update_attributes! found_at: DateTime.now
   end
 
   def found?

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -12,7 +12,12 @@ class Match < ApplicationRecord
   scope :open, -> { where(found_at: nil, ignored_at: nil) }
 
   validates :matched_at, presence: true
+  validate :closed_match_status_cannot_be_updated
   validate :seeker_cannot_be_opponent
+
+  def closed?
+    found? || ignored?
+  end
 
   def found!
     update_attributes found_at: DateTime.now
@@ -22,12 +27,26 @@ class Match < ApplicationRecord
     found_at.present?
   end
 
+  def ignored?
+    ignored_at.present?
+  end
+
+  def open?
+    !closed?
+  end
+
   def opponent_for(player)
     return opponent if player == seeker
     return seeker if player == opponent
   end
 
   private
+
+  def closed_match_status_cannot_be_updated
+    if found? && ignored?
+      errors.add(:base, "Match is not open")
+    end
+  end
 
   def seeker_cannot_be_opponent
     if seeker_id.to_i == opponent_id.to_i

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -14,6 +14,14 @@ class Match < ApplicationRecord
   validates :matched_at, presence: true
   validate :seeker_cannot_be_opponent
 
+  def found!
+    update_attributes found_at: DateTime.now
+  end
+
+  def found?
+    found_at.present?
+  end
+
   def opponent_for(player)
     return opponent if player == seeker
     return seeker if player == opponent

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
       post :play, on: :member
     end
     resources :devices, only: [:create, :destroy]
-    resources :matches, only: :create
+    resources :matches, only: :create do
+      post :capture, on: :member
+    end
     resources :players, only: :create
     resources :sessions, only: :create do
       delete :destroy, on: :collection

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -18,6 +18,36 @@ RSpec.describe Match do
     end
   end
 
+  describe "#found!" do
+    subject { create :match }
+
+    it "sets the found_at timestamp" do
+      subject.found!
+
+      expect(subject.found_at).to be_within(1.second).of(DateTime.now)
+    end
+
+    it "updates the record" do
+      subject.found!
+
+      expect(subject).to_not be_changed
+    end
+  end
+
+  describe "#found?" do
+    it "returns true if the found_at timestamp is set" do
+      subject = build :match, :found
+
+      expect(subject).to be_found
+    end
+
+    it "returns false if the found_at timestamp is not set" do
+      subject = build :match
+
+      expect(subject).to_not be_found
+    end
+  end
+
   describe ".ignored" do
     it "returns all matches that were ignored" do
       expect(described_class.ignored).to match_array [ignored]

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe Match do
     end
   end
 
+  describe "#ignored?" do
+    it "returns true if the ignored_at timestamp is set" do
+      subject = build :match, :ignored
+
+      expect(subject).to be_ignored
+    end
+
+    it "returns false if the ignored_at timestamp is not set" do
+      subject = build :match
+
+      expect(subject).to_not be_ignored
+    end
+  end
+
   describe ".in" do
     let(:arena_one) { create :arena }
     let(:arena_two) { create :arena }
@@ -115,6 +129,14 @@ RSpec.describe Match do
       expect(subject).to_not be_valid
       expect(subject.errors[:seeker]).to \
         include "cannot be in a match with themselves"
+    end
+
+    it "does not allow a closed match to be modified" do
+      subject.ignored_at = DateTime.now
+      subject.found_at = DateTime.now
+
+      expect(subject).to_not be_valid
+      expect(subject.errors[:base]).to include "Match is not open"
     end
   end
 end

--- a/spec/requests/capture_player_spec.rb
+++ b/spec/requests/capture_player_spec.rb
@@ -40,7 +40,14 @@ RSpec.describe "POST /api/matches/:id/capture" do
   end
 
   context "with a match that is not open" do
-    xit "returns an unprocessable entity status"
+    let(:match) { create :match, :ignored, arena: arena, seeker: player }
+
+    it "returns an unprocessable entity status" do
+      post url, headers: valid_authed_headers
+
+      expect(response.status).to eq 422
+      expect(json_response[:errors]).to include "Match is not open"
+    end
   end
 
   context "with an arena that the player is not playing in" do

--- a/spec/requests/capture_player_spec.rb
+++ b/spec/requests/capture_player_spec.rb
@@ -19,7 +19,11 @@ RSpec.describe "POST /api/matches/:id/capture" do
       expect(match.reload).to be_found
     end
 
-    xit "returns the json representation of the match" do
+    it "returns the json representation of the match" do
+      post url, headers: valid_authed_headers
+
+      expect(json_response[:data][:type]).to eq "match"
+      expect(json_response[:data][:id]).to eq match.id.to_s
     end
   end
 

--- a/spec/requests/capture_player_spec.rb
+++ b/spec/requests/capture_player_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe "POST /api/matches/:id/capture" do
       expect(match.reload).to be_found
     end
 
+    xit "creates a new match for the seeker"
+    xit "creates a new match for the opponent"
+
     it "returns the json representation of the match" do
       post url, headers: valid_authed_headers
 
@@ -28,16 +31,26 @@ RSpec.describe "POST /api/matches/:id/capture" do
   end
 
   context "with a match that does not exist" do
-    xit "returns a not found status" do
+    it "returns a not found status" do
+      post "/api/matches/-1/capture", headers: valid_authed_headers
+
+      expect(response).to be_not_found
+      expect(json_response[:errors]).to include "Match with id -1 not found"
     end
   end
 
   context "with a match that is not open" do
-    xit "returns an bad request status"
+    xit "returns an unprocessable entity status"
   end
 
   context "with an arena that the player is not playing in" do
-    xit "returns a not authorized status" do
+    let(:match) { create :match }
+
+    it "returns a not authorized status" do
+      post url, headers: valid_authed_headers
+
+      expect(response).to be_unauthorized
+      expect(json_response[:errors]).to include "Not authorized to play in that Match"
     end
   end
 end

--- a/spec/requests/capture_player_spec.rb
+++ b/spec/requests/capture_player_spec.rb
@@ -12,5 +12,28 @@ RSpec.describe "POST /api/matches/:id/capture" do
 
       expect(response).to be_ok
     end
+
+    it "marks the match as found" do
+      post url, headers: valid_authed_headers
+
+      expect(match.reload).to be_found
+    end
+
+    xit "returns the json representation of the match" do
+    end
+  end
+
+  context "with a match that does not exist" do
+    xit "returns a not found status" do
+    end
+  end
+
+  context "with a match that is not open" do
+    xit "returns an bad request status"
+  end
+
+  context "with an arena that the player is not playing in" do
+    xit "returns a not authorized status" do
+    end
   end
 end

--- a/spec/requests/capture_player_spec.rb
+++ b/spec/requests/capture_player_spec.rb
@@ -24,7 +24,10 @@ RSpec.describe "POST /api/matches/:id/capture" do
         have_enqueued_job(MakeMatchJob).with(match.seeker_id, match.arena_id)
     end
 
-    xit "creates a new match for the opponent"
+    it "creates a new match for the opponent" do
+      expect { post url, headers: valid_authed_headers }.to \
+        have_enqueued_job(MakeMatchJob).with(match.opponent_id, match.arena_id)
+    end
 
     it "returns the json representation of the match" do
       post url, headers: valid_authed_headers

--- a/spec/requests/capture_player_spec.rb
+++ b/spec/requests/capture_player_spec.rb
@@ -60,4 +60,20 @@ RSpec.describe "POST /api/matches/:id/capture" do
       expect(json_response[:errors]).to include "Not authorized to play in that Match"
     end
   end
+
+  it_behaves_like "an authenticated request" do
+    let(:make_request) do
+      -> (headers) do
+        post url, headers: valid_headers.merge(headers)
+      end
+    end
+  end
+
+  it_behaves_like "a request responding to correct headers" do
+    let(:make_request) do
+      -> (headers) do
+        post url, headers: valid_headers.merge(headers)
+      end
+    end
+  end
 end

--- a/spec/requests/capture_player_spec.rb
+++ b/spec/requests/capture_player_spec.rb
@@ -1,0 +1,16 @@
+require "request_helper"
+
+RSpec.describe "POST /api/matches/:id/capture" do
+  let(:arena) { create :arena }
+  let(:match) { create :match, arena: arena, seeker: player }
+  let(:player) { create :player, :authorized, arenas: [arena] }
+  let(:url) { "/api/matches/#{match.id}/capture" }
+
+  context "with a valid request" do
+    it "returns an ok status" do
+      post url, headers: valid_authed_headers
+
+      expect(response).to be_ok
+    end
+  end
+end

--- a/spec/requests/capture_player_spec.rb
+++ b/spec/requests/capture_player_spec.rb
@@ -19,7 +19,11 @@ RSpec.describe "POST /api/matches/:id/capture" do
       expect(match.reload).to be_found
     end
 
-    xit "creates a new match for the seeker"
+    it "creates a new match for the seeker" do
+      expect { post url, headers: valid_authed_headers }.to \
+        have_enqueued_job(MakeMatchJob).with(match.seeker_id, match.arena_id)
+    end
+
     xit "creates a new match for the opponent"
 
     it "returns the json representation of the match" do


### PR DESCRIPTION
Creates an endpoint for `POST /api/matches/:id/capture` which allows a user to capture another player. The match is marked as found and two new matches are generated for the `opponent` and `seeker`.