### PR TITLE
Leave arena endpoint

### DIFF
--- a/app/controllers/api/arenas_controller.rb
+++ b/app/controllers/api/arenas_controller.rb
@@ -7,6 +7,10 @@ class API::ArenasController < ApplicationController
   end
 
   def leave
+    arena = Arena.find params[:id]
+    player_arena = PlayerArena.find_by player_id: current_user.id, arena: arena
+    player_arena.destroy!
+
     head :no_content
   end
 

--- a/app/controllers/api/arenas_controller.rb
+++ b/app/controllers/api/arenas_controller.rb
@@ -6,6 +6,10 @@ class API::ArenasController < ApplicationController
     render json: ArenaSerializer.new(arenas).serialized_json
   end
 
+  def leave
+    head :no_content
+  end
+
   def play
     arena = Arena.find params[:id]
 

--- a/app/controllers/api/arenas_controller.rb
+++ b/app/controllers/api/arenas_controller.rb
@@ -9,6 +9,7 @@ class API::ArenasController < ApplicationController
   def leave
     arena = Arena.find params[:id]
     player_arena = PlayerArena.find_by player_id: current_user.id, arena: arena
+    raise ActiveRecord::RecordNotFound, "Player not found in Arena" if player_arena.nil?
     player_arena.destroy!
 
     head :no_content

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,8 +15,12 @@ class ApplicationController < ActionController::API
   end
 
   rescue_from ActiveRecord::RecordNotFound do |exception|
-    exception = "#{exception.model} with #{exception.primary_key} "\
-                "#{exception.id} not found"
+    if exception.model.present?
+      exception = "#{exception.model} with #{exception.primary_key} "\
+                  "#{exception.id} not found"
+    else
+      exception = exception.message
+    end
     render_errors exception, :not_found
   end
 

--- a/app/documentation/arenas.rb
+++ b/app/documentation/arenas.rb
@@ -133,6 +133,30 @@ module Documentation
           end
         end
 
+        swagger_path "/arenas/{id}/leave" do
+          operation :post do
+            key :summary, "Remove a player from an arena"
+            key :description, "Removes a player from an arena by removing the "\
+                              "assigned player so they can no longer be found there."
+            key :tags, ["ARENAS"]
+            security do
+              key :Bearer, []
+            end
+            response 204 do
+              key :description, "No content is returned."
+            end
+            response 401 do
+              key :description, "Unauthorized"
+              schema do
+                key :type, :string
+              end
+              example name: JSONAPI::MEDIA_TYPE do
+                key :errors, "Unauthorized"
+              end
+            end
+          end
+        end
+
         swagger_schema :Arena do
           key :type, :object
           key :required, [:id,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
     resources :arenas, only: :index do
+      post :leave, on: :member
       post :play, on: :member
     end
     resources :devices, only: [:create, :destroy]

--- a/spec/requests/arena_leave_spec.rb
+++ b/spec/requests/arena_leave_spec.rb
@@ -29,4 +29,29 @@ RSpec.describe "POST /api/arenas/:id/leave" do
       expect(json_response[:errors]).to include "Player not found in Arena"
     end
   end
+
+  context "with an invalid arena id" do
+    it "returns a not found status" do
+      post "/api/arenas/1234/leave", headers: valid_authed_headers
+
+      expect(response).to be_not_found
+      expect(json_response[:errors]).to include "Arena with id 1234 not found"
+    end
+  end
+
+  it_behaves_like "an authenticated request" do
+    let(:make_request) do
+      -> (headers) do
+        post "/api/arenas/#{arena.id}/leave", headers: valid_headers.merge(headers)
+      end
+    end
+  end
+
+  it_behaves_like "a request responding to correct headers" do
+    let(:make_request) do
+      -> (headers) do
+        post "/api/arenas/#{arena.id}/leave", headers: valid_headers.merge(headers)
+      end
+    end
+  end
 end

--- a/spec/requests/arena_leave_spec.rb
+++ b/spec/requests/arena_leave_spec.rb
@@ -2,13 +2,20 @@ require "request_helper"
 
 RSpec.describe "POST /api/arenas/:id/leave" do
   let(:arena) { create :arena }
-  let(:player) { create :player, :authorized, arenas: [arena] }
+  let!(:player) { create :player, :authorized, arenas: [arena] }
 
   context "with a valid request" do
     it "returns a no content status" do
       post "/api/arenas/#{arena.id}/leave", headers: valid_authed_headers
 
       expect(response).to be_no_content
+    end
+
+    it "removes the player from the arena" do
+      expect { post "/api/arenas/#{arena.id}/leave",
+               headers: valid_authed_headers }.to \
+               change { PlayerArena.count }.by -1
+      expect(player.reload.arenas).to be_empty
     end
   end
 end

--- a/spec/requests/arena_leave_spec.rb
+++ b/spec/requests/arena_leave_spec.rb
@@ -18,4 +18,15 @@ RSpec.describe "POST /api/arenas/:id/leave" do
       expect(player.reload.arenas).to be_empty
     end
   end
+
+  context "with an arena that the player is not in" do
+    it "returns a not found status" do
+      player.arenas.clear
+
+      post "/api/arenas/#{arena.id}/leave", headers: valid_authed_headers
+
+      expect(response).to be_not_found
+      expect(json_response[:errors]).to include "Player not found in Arena"
+    end
+  end
 end

--- a/spec/requests/arena_leave_spec.rb
+++ b/spec/requests/arena_leave_spec.rb
@@ -1,0 +1,14 @@
+require "request_helper"
+
+RSpec.describe "POST /api/arenas/:id/leave" do
+  let(:arena) { create :arena }
+  let(:player) { create :player, :authorized, arenas: [arena] }
+
+  context "with a valid request" do
+    it "returns a no content status" do
+      post "/api/arenas/#{arena.id}/leave", headers: valid_authed_headers
+
+      expect(response).to be_no_content
+    end
+  end
+end


### PR DESCRIPTION
This adds the endpoint for a player to be able to leave an `Arena`. The url is `POST /api/arenas/:id/leave`.