### PR TITLE
Duplicate device registration fix

### DIFF
--- a/app/controllers/api/devices_controller.rb
+++ b/app/controllers/api/devices_controller.rb
@@ -2,10 +2,16 @@ class API::DevicesController < ApplicationController
   before_action :require_authorization
 
   def create
-    device = Device.create! device_params.merge(player_id: current_user.id,
-                                                registered_at: DateTime.now)
+    device = Device.find_by player_id: current_user.id, token: device_params[:token]
+    if device.nil?
+      device = Device.create! device_params.merge(player_id: current_user.id,
+                                                  registered_at: DateTime.now)
+      status = :created
+    else
+      status = :ok
+    end
 
-    render json: DeviceSerializer.new(device).serialized_json, status: :created
+    render json: DeviceSerializer.new(device).serialized_json, status: status
   end
 
   def destroy

--- a/spec/requests/register_device_spec.rb
+++ b/spec/requests/register_device_spec.rb
@@ -44,6 +44,16 @@ RSpec.describe "POST /api/devices" do
     end
   end
 
+  context "with a device already registered" do
+    let!(:device) { create :device, player: player, token: token }
+
+    it "returns an ok status" do
+      post "/api/devices", params: valid_parameters, headers: valid_authed_headers
+
+      expect(response).to be_ok
+    end
+  end
+
   context "with an incorrect json payload" do
     let(:parameters) do
       {

--- a/spec/requests/register_device_spec.rb
+++ b/spec/requests/register_device_spec.rb
@@ -52,6 +52,11 @@ RSpec.describe "POST /api/devices" do
 
       expect(response).to be_ok
     end
+
+    it "does not create a new device" do
+      expect { post "/api/devices", params: valid_parameters,
+               headers: valid_authed_headers }.to_not change { Device.count }
+    end
   end
 
   context "with an incorrect json payload" do


### PR DESCRIPTION
Do not throw an error if the device is trying to be registered again.