### PR TITLE
Dont match existing matches

### DIFF
--- a/app/models/match_maker.rb
+++ b/app/models/match_maker.rb
@@ -1,5 +1,7 @@
 class MatchMaker
   def self.match!(player:, arena:)
+    return nil if player.matched_in?(arena)
+
     opponent = Player.in(arena).unmatched.not_already_matched_with(player, arena).sample
 
     if opponent

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -61,6 +61,12 @@ class Player < ApplicationRecord
     update_attributes(api_key: TokenGenerator.generate)
   end
 
+  def matched_in?(arena)
+    Match.in(arena).where(seeker_id: id)
+      .or(Match.in(arena).where(opponent_id: id))
+      .exists?
+  end
+
   private
 
   def clear_virtual_password

--- a/spec/models/match_maker_spec.rb
+++ b/spec/models/match_maker_spec.rb
@@ -64,5 +64,17 @@ RSpec.describe MatchMaker do
         expect(match.arena).to eq arena
       end
     end
+
+    context "with a new opponent in the same arena" do
+      let!(:player_three) { create :player, arenas: [arena] }
+
+      before do
+        create :match, arena: arena, opponent: player_one, seeker: player_two
+      end
+
+      it "does not create a new match" do
+        expect(described_class.match!(player: player_one, arena: arena)).to be_nil
+      end
+    end
   end
 end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -89,6 +89,29 @@ RSpec.describe Player do
     end
   end
 
+  describe "#matched_in?" do
+    let(:arena) { create :arena }
+    subject { create :player, arenas: [arena] }
+
+    it "returns true if the player is a seeker in a match in the arena" do
+      create :match, seeker: subject, arena: arena
+
+      expect(subject).to be_matched_in arena
+    end
+
+    it "returns true if the player is an opponent in a match in the arena" do
+      create :match, opponent: subject, arena: arena
+
+      expect(subject).to be_matched_in arena
+    end
+
+    it "returns false if the player is a seeker in a match in another arena" do
+      create :match, opponent: subject
+
+      expect(subject).to_not be_matched_in arena
+    end
+  end
+
   describe "#password" do
     subject { build :player }
 


### PR DESCRIPTION
This fixes an issue with the match maker where it would place opponents in a match that were already in a match.

The issue was realized with the following scenario:

1. A first player would join an arena and a job would fire off to find a match.
2. That match was never found because there were no other players
3. A second player would join the same arena and a job would fire off to find a match
4. That match was found and the job was successful
5. The original job (from 1) would be retried and fail because there were no other opponents
6. A third player would join the same arena and a job would fire off to find a match
7. That job would fail because there were no opponents for that third player
8. The original job would be retrieved and *succeed* because the opponnent (the third player) would now be available
