### PR TITLE
Do not reschedule the job if a match is found

### DIFF
--- a/app/jobs/make_match_job.rb
+++ b/app/jobs/make_match_job.rb
@@ -11,6 +11,8 @@ class MakeMatchJob < ApplicationJob
     player = Player.find player_id
     arena = Arena.find arena_id
 
+    return if player.matched_in?(arena)
+
     match = MatchMaker.match! player: player, arena: arena
     raise MatchNotFoundError if match.nil?
   rescue ActiveRecord::RecordNotFound => e

--- a/spec/jobs/make_match_job_spec.rb
+++ b/spec/jobs/make_match_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe MakeMatchJob do
   end
 
   it "reschedules itself if a match was not found" do
-    create :match, arena: arena, seeker: player
+    create :match, :ignored, arena: arena, seeker: player
 
     expect_any_instance_of(described_class).to \
       receive(:retry_job).with(wait: 2.minutes)


### PR DESCRIPTION
This adds a performance enhancement where the job is not rescheduled if a match is not found if there is already an existing match for a player.