### PR TITLE
Player show endpoint

### DIFF
--- a/app/controllers/api/players_controller.rb
+++ b/app/controllers/api/players_controller.rb
@@ -6,6 +6,10 @@ class API::PlayersController < ApplicationController
            status: :created
   end
 
+  def show
+    head :ok
+  end
+
   private
 
   def player_params

--- a/app/controllers/api/players_controller.rb
+++ b/app/controllers/api/players_controller.rb
@@ -7,7 +7,9 @@ class API::PlayersController < ApplicationController
   end
 
   def show
-    head :ok
+    player = Player.find params[:id]
+
+    render json: PlayerSerializer.new(player).serialized_json
   end
 
   private

--- a/app/controllers/api/players_controller.rb
+++ b/app/controllers/api/players_controller.rb
@@ -11,6 +11,8 @@ class API::PlayersController < ApplicationController
   def show
     player = Player.find params[:id]
 
+    authorize! :read, player, message: "Player could not be found"
+
     hash = PlayerSerializer.new(player).serializable_hash
     hash[:data][:attributes].delete(:api_key)
 

--- a/app/controllers/api/players_controller.rb
+++ b/app/controllers/api/players_controller.rb
@@ -1,4 +1,6 @@
 class API::PlayersController < ApplicationController
+  before_action :require_authorization, except: :create
+
   def create
     player = Player.create! player_params.merge(api_key: TokenGenerator.generate)
 
@@ -9,7 +11,10 @@ class API::PlayersController < ApplicationController
   def show
     player = Player.find params[:id]
 
-    render json: PlayerSerializer.new(player).serialized_json
+    hash = PlayerSerializer.new(player).serializable_hash
+    hash[:data][:attributes].delete(:api_key)
+
+    render json: PlayerSerializer.to_json(hash)
   end
 
   private

--- a/app/jobs/make_match_job.rb
+++ b/app/jobs/make_match_job.rb
@@ -11,7 +11,7 @@ class MakeMatchJob < ApplicationJob
     player = Player.find player_id
     arena = Arena.find arena_id
 
-    return if player.matched_in?(arena)
+    return if player.openly_matched_in?(arena)
 
     match = MatchMaker.match! player: player, arena: arena
     raise MatchNotFoundError if match.nil?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,6 +10,14 @@ class Ability
       can [:create, :read, :update], Match do |match|
         match.arena && match.arena.playable_by?(player)
       end
+
+      can :manage, Player do |someone_else|
+        someone_else == player
+      end
+
+      can :read, Player do |someone_else|
+        player.matched_with?(someone_else)
+      end
     end
   end
 end

--- a/app/models/match_maker.rb
+++ b/app/models/match_maker.rb
@@ -1,6 +1,6 @@
 class MatchMaker
   def self.match!(player:, arena:)
-    return nil if player.matched_in?(arena)
+    return nil if player.openly_matched_in?(arena)
 
     opponent = Player.in(arena).unmatched.not_already_matched_with(player, arena).sample
 

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -61,7 +61,7 @@ class Player < ApplicationRecord
     update_attributes(api_key: TokenGenerator.generate)
   end
 
-  def matched_in?(arena)
+  def openly_matched_in?(arena)
     Match.in(arena).open.where(seeker_id: id)
       .or(Match.in(arena).open.where(opponent_id: id))
       .exists?

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -61,6 +61,10 @@ class Player < ApplicationRecord
     update_attributes(api_key: TokenGenerator.generate)
   end
 
+  def matched_with?(player)
+    Match.where(seeker_id: id).or(Match.where(opponent_id: id)).exists?
+  end
+
   def openly_matched_in?(arena)
     Match.in(arena).open.where(seeker_id: id)
       .or(Match.in(arena).open.where(opponent_id: id))

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -62,7 +62,7 @@ class Player < ApplicationRecord
   end
 
   def matched_with?(player)
-    Match.where(seeker_id: id).or(Match.where(opponent_id: id)).exists?
+    Match.where(seeker_id: player).or(Match.where(opponent_id: player)).exists?
   end
 
   def openly_matched_in?(arena)

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -10,8 +10,7 @@ class Player < ApplicationRecord
   mount_base64_uploader :avatar, AvatarUploader
 
   scope :already_matched_with, ->(player, arena) do
-    players_in_common_matches = Match.in(arena).where(seeker_id: player)
-      .or(Match.in(arena).where(opponent_id: player))
+    players_in_common_matches = Match.in(arena).for(player)
       .pluck(:seeker_id, :opponent_id).flatten
     where(id: players_in_common_matches).where.not(id: player)
   end
@@ -62,13 +61,11 @@ class Player < ApplicationRecord
   end
 
   def matched_with?(player)
-    Match.where(seeker_id: player).or(Match.where(opponent_id: player)).exists?
+    Match.for(player).exists?
   end
 
   def openly_matched_in?(arena)
-    Match.in(arena).open.where(seeker_id: id)
-      .or(Match.in(arena).open.where(opponent_id: id))
-      .exists?
+    Match.in(arena).open.for(id).exists?
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
     resources :matches, only: :create do
       post :capture, on: :member
     end
-    resources :players, only: :create
+    resources :players, only: [:create, :show]
     resources :sessions, only: :create do
       delete :destroy, on: :collection
     end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -60,4 +60,18 @@ RSpec.describe Ability do
       expect(subject).to_not be_able_to :read, match
     end
   end
+
+  context "for an player" do
+    let(:someone_else) { create :player }
+
+    it "can manage their own player" do
+      expect(subject).to be_able_to :manage, player
+    end
+
+    it "can read a player they have been matched up with" do
+      create :match, seeker: player, opponent: someone_else
+
+      expect(subject).to be_able_to :read, someone_else
+    end
+  end
 end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -89,32 +89,32 @@ RSpec.describe Player do
     end
   end
 
-  describe "#matched_in?" do
+  describe "#openly_matched_in?" do
     let(:arena) { create :arena }
     subject { create :player, arenas: [arena] }
 
     it "returns true if the player is a seeker in a match in the arena" do
       create :match, seeker: subject, arena: arena
 
-      expect(subject).to be_matched_in arena
+      expect(subject).to be_openly_matched_in arena
     end
 
     it "returns true if the player is an opponent in a match in the arena" do
       create :match, opponent: subject, arena: arena
 
-      expect(subject).to be_matched_in arena
+      expect(subject).to be_openly_matched_in arena
     end
 
     it "returns false if the match is not open" do
       create :match, :found, opponent: subject, arena: arena
 
-      expect(subject).to_not be_matched_in arena
+      expect(subject).to_not be_openly_matched_in arena
     end
 
     it "returns false if the player is a seeker in a match in another arena" do
       create :match, opponent: subject
 
-      expect(subject).to_not be_matched_in arena
+      expect(subject).to_not be_openly_matched_in arena
     end
   end
 

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -89,6 +89,27 @@ RSpec.describe Player do
     end
   end
 
+  describe "#matched_with?" do
+    let(:someone_else) { create :player }
+    subject { create :player }
+
+    it "returns true if the player is a seeker in any match with the player" do
+      create :match, seeker: subject, opponent: someone_else
+
+      expect(subject).to be_matched_with someone_else
+    end
+
+    it "returns true if the player is an opponent in any match with the player" do
+      create :match, seeker: someone_else, opponent: subject
+
+      expect(subject).to be_matched_with someone_else
+    end
+
+    it "returns false if the player was never matched" do
+      expect(subject).to_not be_matched_with someone_else
+    end
+  end
+
   describe "#openly_matched_in?" do
     let(:arena) { create :arena }
     subject { create :player, arenas: [arena] }

--- a/spec/requests/retrieve_player_spec.rb
+++ b/spec/requests/retrieve_player_spec.rb
@@ -10,5 +10,12 @@ RSpec.describe "GET /api/players/:id" do
 
       expect(response).to be_ok
     end
+
+    it "returns the json representation of a player" do
+      get url, headers: valid_headers
+
+      expect(json_response[:data][:type]).to eq "player"
+      expect(json_response[:data][:id]).to eq player.id.to_s
+    end
   end
 end

--- a/spec/requests/retrieve_player_spec.rb
+++ b/spec/requests/retrieve_player_spec.rb
@@ -1,0 +1,14 @@
+require "request_helper"
+
+RSpec.describe "GET /api/players/:id" do
+  let(:player) { create :player, :authorized }
+  let(:url) { "/api/players/#{player.id}" }
+
+  context "with a valid request" do
+    it "returns an ok status" do
+      get url, headers: valid_authed_headers
+
+      expect(response).to be_ok
+    end
+  end
+end

--- a/spec/requests/retrieve_player_spec.rb
+++ b/spec/requests/retrieve_player_spec.rb
@@ -25,6 +25,26 @@ RSpec.describe "GET /api/players/:id" do
     end
   end
 
+  context "with an invalid player id" do
+    it "returns a not found status" do
+      get "/api/players/1234", headers: valid_authed_headers
+
+      expect(response).to be_not_found
+      expect(json_response[:errors]).to include "Player with id 1234 not found"
+    end
+  end
+
+  context "with a player that the player cannot read" do
+    let(:someone_else) { create :player }
+
+    it "returns an unauthorized status" do
+      get "/api/players/#{someone_else.id}", headers: valid_authed_headers
+
+      expect(response).to be_unauthorized
+      expect(json_response[:errors]).to include "Player could not be found"
+    end
+  end
+
   it_behaves_like "an authenticated request" do
     let(:make_request) do
       -> (headers) do

--- a/spec/requests/retrieve_player_spec.rb
+++ b/spec/requests/retrieve_player_spec.rb
@@ -12,10 +12,32 @@ RSpec.describe "GET /api/players/:id" do
     end
 
     it "returns the json representation of a player" do
-      get url, headers: valid_headers
+      get url, headers: valid_authed_headers
 
       expect(json_response[:data][:type]).to eq "player"
       expect(json_response[:data][:id]).to eq player.id.to_s
+    end
+
+    it "does not include the api key in the json representaiton" do
+      get url, headers: valid_authed_headers
+
+      expect(json_response[:data][:attributes]).to_not include :api_key
+    end
+  end
+
+  it_behaves_like "an authenticated request" do
+    let(:make_request) do
+      -> (headers) do
+        get url, headers: valid_headers.merge(headers)
+      end
+    end
+  end
+
+  it_behaves_like "a request responding to correct headers" do
+    let(:make_request) do
+      -> (headers) do
+        get url, headers: valid_authed_headers.merge(headers)
+      end
     end
   end
 end


### PR DESCRIPTION
Provides an endpoint for `GET /api/players/:id` so that the app can view opponent details. This also ensures that the `Player` is authorized to view the specific user. This means that it must be that player or in a previous `Match` with the current user.