### PR TITLE
Add category to notification

### DIFF
--- a/app/models/match_maker.rb
+++ b/app/models/match_maker.rb
@@ -9,7 +9,7 @@ class MatchMaker
                             opponent: opponent,
                             arena: arena,
                             matched_at: DateTime.now
-      MatchNotifier.new(match).notify!
+      NewMatchNotifier.new(match).notify!
       match
     end
   end

--- a/app/models/new_match_notifier.rb
+++ b/app/models/new_match_notifier.rb
@@ -1,6 +1,6 @@
 require "houston"
 
-class MatchNotifier
+class NewMatchNotifier
   attr_reader :match
 
   def initialize(match)

--- a/app/models/new_match_notifier.rb
+++ b/app/models/new_match_notifier.rb
@@ -34,6 +34,7 @@ class NewMatchNotifier
     if opponent = match.opponent_for(player)
       notification = Houston::Notification.new(device: token)
       notification.alert = "Gotcha! #{opponent.name} is out to get 'cha!"
+      notification.category = :new_match
       notification.badge = Match.for(player).open.count
       notification.custom_data = MatchSerializer.new(match).serializable_hash
       notification

--- a/spec/models/match_maker_spec.rb
+++ b/spec/models/match_maker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MatchMaker do
     let!(:player_one) { create :player, arenas: [arena] }
     let!(:player_two) { create :player, arenas: [arena] }
 
-    before { allow_any_instance_of(MatchNotifier).to receive(:notify!) }
+    before { allow_any_instance_of(NewMatchNotifier).to receive(:notify!) }
 
     context "with two unmatched players in the same arena" do
       it "creates a new match between the two players" do
@@ -19,9 +19,9 @@ RSpec.describe MatchMaker do
       end
 
       it "notifies the players of the match" do
-        expect(MatchNotifier).to \
+        expect(NewMatchNotifier).to \
           receive(:new).with(an_instance_of(Match)).and_call_original
-        expect_any_instance_of(MatchNotifier).to receive(:notify!)
+        expect_any_instance_of(NewMatchNotifier).to receive(:notify!)
 
         described_class.match! player: player_two, arena: arena
       end

--- a/spec/models/new_match_notifier_spec.rb
+++ b/spec/models/new_match_notifier_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe NewMatchNotifier do
       subject.notify_player!(seeker)
     end
 
+    it "sends the appropriate category" do
+      expect_any_instance_of(Houston::Notification).to \
+        receive(:category=).with(:new_match).and_call_original
+
+      subject.notify_player!(seeker)
+    end
+
     it "tells the player how many open matches they have" do
       create :match, opponent: seeker
 

--- a/spec/models/new_match_notifier_spec.rb
+++ b/spec/models/new_match_notifier_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe MatchNotifier do
+RSpec.describe NewMatchNotifier do
   let(:match) { create :match, seeker: seeker, opponent: opponent }
   let(:opponent) { create :player, name: "Robert Plant" }
   let(:seeker) { create :player, name: "Jimmy Page" }


### PR DESCRIPTION
Adds a category to the push notifications so the mobile client knows what to do when it receives the push notification.