### PR TITLE
Increase uploader size to 2 megabytes

### DIFF
--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -4,7 +4,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
   end
 
   def size_range
-    1..1.megabyte
+    1..2.megabyte
   end
 
   def store_dir

--- a/spec/uploaders/avatar_uploader_spec.rb
+++ b/spec/uploaders/avatar_uploader_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe AvatarUploader do
   end
 
   describe "#size_range" do
-    it "allows an size range from 0 to 1 megabytes" do
-      expect(subject.size_range).to eq 1..1.megabyte
+    it "allows an size range from 0 to 2 megabytes" do
+      expect(subject.size_range).to eq 1..2.megabyte
     end
   end
 


### PR DESCRIPTION
Increase the size allowed for avatar uploads from 1 megabyte to 2 megabytes.