### PR TITLE
Scope device token to player

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -4,5 +4,6 @@ class Device < ApplicationRecord
   scope :for, ->(player) { where(player_id: player) }
 
   validates :token, presence: true,
-                    uniqueness: { message: "has already been registered" }
+                    uniqueness: { scope: :player_id,
+                                  message: "has already been registered" }
 end

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Device do
     end
 
     it "requires the token to be unique" do
-      create :device, token: subject.token
+      create :device, player_id: subject.player_id, token: subject.token
 
       expect(subject).to_not be_valid
       expect(subject.errors[:token]).to include "has already been registered"


### PR DESCRIPTION
Scopes the device token uniqueness to the player so that one device can have multiple registrations.