### PR TITLE
Captured players endpoint

### DIFF
--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -6,10 +6,15 @@ class API::MatchesController < ApplicationController
     authorize! :update, match, message: "Not authorized to play in that Match"
     match.pending!
 
-=begin
+    render json: MatchSerializer.new(match).serialized_json
+  end
+
+  def captured
+    match = Match.find params[:id]
+    match.found! match_params[:confirmation_code]
+
     MakeMatchJob.perform_later match.seeker_id, match.arena_id
     MakeMatchJob.perform_later match.opponent_id, match.arena_id
-=end
 
     render json: MatchSerializer.new(match).serialized_json
   end
@@ -30,6 +35,6 @@ class API::MatchesController < ApplicationController
   def match_params
     params.require(:data)
           .require(:attributes)
-          .permit(:arena_id)
+          .permit(:arena_id, :confirmation_code)
   end
 end

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -6,6 +6,9 @@ class API::MatchesController < ApplicationController
     authorize! :update, match, message: "Not authorized to play in that Match"
     match.pending!
 
+    ConfirmCaptureNotifier.new(match)
+      .notify_player!(match.opponent_for(current_user))
+
     render json: MatchSerializer.new(match).serialized_json
   end
 

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -4,7 +4,7 @@ class API::MatchesController < ApplicationController
   def capture
     match = Match.find params[:id]
     authorize! :update, match, message: "Not authorized to play in that Match"
-    match.found!
+    match.pending!
 
     MakeMatchJob.perform_later match.seeker_id, match.arena_id
     MakeMatchJob.perform_later match.opponent_id, match.arena_id

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -11,6 +11,13 @@ class API::MatchesController < ApplicationController
 
   def captured
     match = Match.find params[:id]
+
+    authorize! :update, match, message: "Not authorized to play in that Match"
+    unless match.pending?
+      raise JSONAPI::Exceptions::PreconditionFailedError
+        .new("Match is not pending")
+    end
+
     match.found! match_params[:confirmation_code]
 
     MakeMatchJob.perform_later match.seeker_id, match.arena_id

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -27,6 +27,7 @@ class API::MatchesController < ApplicationController
         .new("Confirmation code does not match")
     end
 
+    SuccessfulCaptureJob.perform_later match.id
     MakeMatchJob.perform_later match.seeker_id, match.arena_id
     MakeMatchJob.perform_later match.opponent_id, match.arena_id
 

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -19,6 +19,10 @@ class API::MatchesController < ApplicationController
     end
 
     match.found! match_params[:confirmation_code]
+    unless match.found?
+      raise JSONAPI::Exceptions::InvalidParameterError
+        .new("Confirmation code does not match")
+    end
 
     MakeMatchJob.perform_later match.seeker_id, match.arena_id
     MakeMatchJob.perform_later match.opponent_id, match.arena_id

--- a/app/controllers/api/matches_controller.rb
+++ b/app/controllers/api/matches_controller.rb
@@ -6,8 +6,10 @@ class API::MatchesController < ApplicationController
     authorize! :update, match, message: "Not authorized to play in that Match"
     match.pending!
 
+=begin
     MakeMatchJob.perform_later match.seeker_id, match.arena_id
     MakeMatchJob.perform_later match.opponent_id, match.arena_id
+=end
 
     render json: MatchSerializer.new(match).serialized_json
   end

--- a/app/documentation/matches.rb
+++ b/app/documentation/matches.rb
@@ -24,7 +24,7 @@ module Documentation
                   id: "12345",
                   type: "match",
                   attributes: {
-                    confirmation_code: null,
+                    confirmation_code: "",
                     found_at: 5632493294,
                     matched_at: 783287834764,
                   },
@@ -61,6 +61,114 @@ module Documentation
               end
               example name: JSONAPI::MEDIA_TYPE do
                 key :errors, "Unauthorized"
+              end
+            end
+          end
+        end
+
+        swagger_path "/matches/:id/captured" do
+          operation :post do
+            key :summary, "Mark the match as found between the seeker and the opponent"
+            key :description, "Marks the match as found if the confirmation "\
+                              "code matches. Scores the match and sends a "\
+                              "successful match push notification to the "\
+                              "seeker and the opponent."
+            key :tags, ["MATCHES"]
+            security do
+              key :Bearer, []
+            end
+            parameter do
+              key :name, :attributes
+              key :type, :object
+              key :in, :body
+              key :description, "The match information to confirm"
+              schema do
+                key :"$ref", :MatchInput
+              end
+            end
+            response 200 do
+              key :description, "A JSON API formatted representation of the single Match that was found."
+              schema do
+                key :"$ref", :Match
+              end
+              example name: JSONAPI::MEDIA_TYPE do
+                key :data, {
+                  id: "12345",
+                  type: "match",
+                  attributes: {
+                    confirmation_code: "0437",
+                    found_at: 5632493294,
+                    matched_at: 783287834764,
+                  },
+                  relationships: {
+                    arena: {
+                      data: {
+                        id: "67893",
+                        type: "arena"
+                      }
+                    },
+                    opponent: {
+                      data: {
+                        id: "53273",
+                        type: "player"
+                      }
+                    },
+                    seeker: {
+                      data: {
+                        id: "77349543",
+                        type: "player"
+                      }
+                    }
+                  }
+                }
+              end
+            end
+            response 400 do
+              key :description, "Confirmation code does not match"
+              schema do
+                key :type, :array
+                items do
+                  key :"$ref", :Error
+                end
+              end
+              example name: JSONAPI::MEDIA_TYPE do
+                key :errors, [{
+                  title: "Invalid parameter",
+                  detail: "Confirmation code does not match",
+                  status: 400
+                }]
+              end
+            end
+            response 401 do
+              key :description, "Unauthorized"
+              schema do
+                key :type, :array
+                items do
+                  key :"$ref", :Error
+                end
+              end
+              example name: JSONAPI::MEDIA_TYPE do
+                key :errors, [{
+                  title: "Not Authorized",
+                  detail: "Not Authorized",
+                  status: 401
+                }]
+              end
+            end
+            response 412 do
+              key :description, "Match passed in is not pending"
+              schema do
+                key :type, :array
+                items do
+                  key :"$ref", :Error
+                end
+              end
+              example name: JSONAPI::MEDIA_TYPE do
+                key :errors, [{
+                  title: "Precondition failed",
+                  detail: "Match was not pending",
+                  status: 412
+                }]
               end
             end
           end
@@ -149,7 +257,24 @@ module Documentation
                 end
               end
             end
+          end
+        end
 
+        swagger_schema :MatchInput do
+          key :type, :object
+          key :required, [:data]
+          property :data do
+            key :type, :object
+            key :required, [:attributes]
+            property :attributes do
+              key :type, :object
+              key :required, [:confirmation_code]
+              property :token do
+                key :type, :integer
+                key :format, :string
+                key :description, "The confirmation code used to confirm the capture"
+              end
+            end
           end
         end
 

--- a/app/documentation/matches.rb
+++ b/app/documentation/matches.rb
@@ -5,9 +5,11 @@ module Documentation
 
         swagger_path "/matches/:id/capture" do
           operation :post do
-            key :summary, "Mark the match as found between the seeker and the opponent"
-            key :description, "Marks the match as found and starts new matches "\
-                              "for both the seeker and the opponent."
+            key :summary, "Mark the match as pending between the seeker and the opponent"
+            key :description, "Marks the match as pending and waits for a "\
+                              "confirmation code for the seeker and the "\
+                              "opponent which can be triggered by a push "\
+                              "notification."
             key :tags, ["MATCHES"]
             security do
               key :Bearer, []
@@ -22,6 +24,7 @@ module Documentation
                   id: "12345",
                   type: "match",
                   attributes: {
+                    confirmation_code: null,
                     found_at: 5632493294,
                     matched_at: 783287834764,
                   },
@@ -82,6 +85,12 @@ module Documentation
             end
             property :attributes do
               key :type, :object
+              property :confirmation_code do
+                key :type, :integer
+                key :format, :string
+                key :description, "A four digit code that can be used to "\
+                                  "confirm a capture."
+              end
               property :found_at do
                 key :type, :integer
                 key :format, :dateTime

--- a/app/documentation/matches.rb
+++ b/app/documentation/matches.rb
@@ -60,7 +60,12 @@ module Documentation
                 end
               end
               example name: JSONAPI::MEDIA_TYPE do
-                key :errors, "Unauthorized"
+                key :errors, [{
+                  code: 401,
+                  title: "Not Authorized",
+                  detail: "Not Authorized",
+                  status: 401
+                }]
               end
             end
           end
@@ -133,6 +138,7 @@ module Documentation
               end
               example name: JSONAPI::MEDIA_TYPE do
                 key :errors, [{
+                  code: 400,
                   title: "Invalid parameter",
                   detail: "Confirmation code does not match",
                   status: 400
@@ -149,6 +155,7 @@ module Documentation
               end
               example name: JSONAPI::MEDIA_TYPE do
                 key :errors, [{
+                  code: 401,
                   title: "Not Authorized",
                   detail: "Not Authorized",
                   status: 401
@@ -165,6 +172,7 @@ module Documentation
               end
               example name: JSONAPI::MEDIA_TYPE do
                 key :errors, [{
+                  code: 412,
                   title: "Precondition failed",
                   detail: "Match was not pending",
                   status: 412

--- a/app/jobs/successful_capture_job.rb
+++ b/app/jobs/successful_capture_job.rb
@@ -1,0 +1,4 @@
+class SuccessfulCaptureJob < ApplicationJob
+  def perform(match_id)
+  end
+end

--- a/app/jobs/successful_capture_job.rb
+++ b/app/jobs/successful_capture_job.rb
@@ -1,4 +1,16 @@
 class SuccessfulCaptureJob < ApplicationJob
+  queue_as :default
+
   def perform(match_id)
+    match = Match.find match_id
+
+    if match.found?
+      Score.captured_player!(match.arena, match.seeker)
+      Score.captured_player!(match.arena, match.opponent)
+      SuccessfulCaptureNotifier.new(match).notify!
+    end
+
+  rescue ActiveRecord::RecordNotFound => e
+    logger.error e
   end
 end

--- a/app/models/confirm_capture_notifier.rb
+++ b/app/models/confirm_capture_notifier.rb
@@ -1,0 +1,29 @@
+class ConfirmCaptureNotifier
+  include PushNotificationNotifier
+
+  attr_reader :match
+
+  def initialize(match)
+    @match = match
+  end
+
+  def notify_player!(player)
+    notifications_for(player).each do |notification|
+      client.push notification unless notification.nil?
+    end
+  end
+
+  private
+
+  def notification(player, token)
+    if opponent = match.opponent_for(player)
+      notification = Houston::Notification.new(device: token)
+      notification.alert = "Gotcha! Looks like you met #{opponent.name}. "\
+                           "Please confirm with his code."
+      notification.category = :confirm_capture
+      notification.badge = Match.for(player).open.count
+      notification.custom_data = MatchSerializer.new(match).serializable_hash
+      notification
+    end
+  end
+end

--- a/app/models/confirm_capture_notifier.rb
+++ b/app/models/confirm_capture_notifier.rb
@@ -8,8 +8,8 @@ class ConfirmCaptureNotifier
   end
 
   def notify_player!(player)
-    notifications_for(player).each do |notification|
-      client.push notification unless notification.nil?
+    notifications_for(player).compact.each do |notification|
+      client.push notification
     end
   end
 

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -21,8 +21,11 @@ class Match < ApplicationRecord
     found? || ignored? || pending?
   end
 
-  def found!
-    update_attributes! found_at: DateTime.now
+  def found!(confirmation_code)
+    if (!confirmation_code.to_s.blank? &&
+        confirmation_code.to_s == self.confirmation_code.to_s)
+      update_attributes! found_at: DateTime.now
+    end
   end
 
   def found?

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -24,7 +24,8 @@ class Match < ApplicationRecord
   def found!(confirmation_code)
     if (!confirmation_code.to_s.blank? &&
         confirmation_code.to_s == self.confirmation_code.to_s)
-      update_attributes! found_at: DateTime.now
+      update_attributes! pending_at: nil,
+                         found_at: DateTime.now
     end
   end
 

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -40,6 +40,10 @@ class Match < ApplicationRecord
     return seeker if player == opponent
   end
 
+  def pending?
+    pending_at.present?
+  end
+
   private
 
   def closed_match_status_cannot_be_updated

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -9,14 +9,14 @@ class Match < ApplicationRecord
   scope :found, -> { where.not(found_at: nil) }
   scope :ignored, -> { where.not(ignored_at: nil) }
   scope :in, ->(arena) { where(arena_id: arena) }
-  scope :open, -> { where(found_at: nil, ignored_at: nil) }
+  scope :open, -> { where(found_at: nil, ignored_at: nil, pending_at: nil) }
 
   validates :matched_at, presence: true
   validate :closed_match_status_cannot_be_updated
   validate :seeker_cannot_be_opponent
 
   def closed?
-    found? || ignored?
+    found? || ignored? || pending?
   end
 
   def found!

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -41,7 +41,8 @@ class Match < ApplicationRecord
   end
 
   def pending!
-    update_attributes! pending_at: DateTime.now
+    update_attributes! confirmation_code: TokenGenerator.generate_code(4),
+                       pending_at: DateTime.now
   end
 
   def pending?

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -27,6 +27,12 @@ class Match < ApplicationRecord
     found_at.present?
   end
 
+  def ignored!
+    update_attributes! pending_at: nil,
+                       confirmation_code: nil,
+                       ignored_at: DateTime.now
+  end
+
   def ignored?
     ignored_at.present?
   end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -40,6 +40,10 @@ class Match < ApplicationRecord
     return seeker if player == opponent
   end
 
+  def pending!
+    update_attributes! pending_at: DateTime.now
+  end
+
   def pending?
     pending_at.present?
   end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -51,7 +51,7 @@ class Match < ApplicationRecord
   private
 
   def closed_match_status_cannot_be_updated
-    if found? && ignored?
+    if (pending? || found?) && ignored?
       errors.add(:base, "Match is not open")
     end
   end

--- a/app/models/match_maker.rb
+++ b/app/models/match_maker.rb
@@ -2,7 +2,10 @@ class MatchMaker
   def self.match!(player:, arena:)
     return nil if player.openly_matched_in?(arena)
 
-    opponent = Player.in(arena).unmatched.not_already_matched_with(player, arena).sample
+    opponent = Player
+                .in(arena)
+                .unmatched.not_already_matched_with(player, arena)
+                .sample
 
     if opponent
       match = Match.create! seeker: player,

--- a/app/models/new_match_notifier.rb
+++ b/app/models/new_match_notifier.rb
@@ -13,8 +13,8 @@ class NewMatchNotifier
   end
 
   def notify_player!(player)
-    notifications_for(player).each do |notification|
-      client.push notification unless notification.nil?
+    notifications_for(player).compact.each do |notification|
+      client.push notification
     end
   end
 

--- a/app/models/new_match_notifier.rb
+++ b/app/models/new_match_notifier.rb
@@ -1,6 +1,6 @@
-require "houston"
-
 class NewMatchNotifier
+  include PushNotificationNotifier
+
   attr_reader :match
 
   def initialize(match)
@@ -19,16 +19,6 @@ class NewMatchNotifier
   end
 
   private
-
-  def client
-    @client ||= Houston::Client.respond_to?(Rails.env) ?
-                  Houston::Client.send(Rails.env) :
-                  Houston::Client.new
-  end
-
-  def notifications_for(player)
-    Device.for(player).map { |device| notification(player, device.token) }
-  end
 
   def notification(player, token)
     if opponent = match.opponent_for(player)

--- a/app/models/push_notification_notifier.rb
+++ b/app/models/push_notification_notifier.rb
@@ -1,0 +1,19 @@
+require "houston"
+
+module PushNotificationNotifier
+  private
+
+  def client
+    @client ||= Houston::Client.respond_to?(Rails.env) ?
+                  Houston::Client.send(Rails.env) :
+                  Houston::Client.new
+  end
+
+  def notifications_for(player)
+    Device.for(player).map { |device| notification(player, device.token) }
+  end
+
+  def notification(player, token)
+    raise NotImplementedError, "Class must implement the notification"
+  end
+end

--- a/app/models/successful_capture_notifier.rb
+++ b/app/models/successful_capture_notifier.rb
@@ -13,8 +13,8 @@ class SuccessfulCaptureNotifier
   end
 
   def notify_player!(player)
-    notifications_for(player).each do |notification|
-      client.push notification unless notification.nil?
+    notifications_for(player).compact.each do |notification|
+      client.push notification
     end
   end
 

--- a/app/models/successful_capture_notifier.rb
+++ b/app/models/successful_capture_notifier.rb
@@ -1,7 +1,33 @@
 class SuccessfulCaptureNotifier
+  include PushNotificationNotifier
+
+  attr_reader :match
+
   def initialize(match)
+    @match = match
   end
 
   def notify!
+    notify_player!(match.seeker)
+    notify_player!(match.opponent)
+  end
+
+  def notify_player!(player)
+    notifications_for(player).each do |notification|
+      client.push notification unless notification.nil?
+    end
+  end
+
+  private
+
+  def notification(player, token)
+    if opponent = match.opponent_for(player)
+      notification = Houston::Notification.new(device: token)
+      notification.alert = "Gotcha! You just met #{opponent.name}!"
+      notification.category = :successful_capture
+      notification.badge = Match.for(player).open.count
+      notification.custom_data = MatchSerializer.new(match).serializable_hash
+      notification
+    end
   end
 end

--- a/app/models/successful_capture_notifier.rb
+++ b/app/models/successful_capture_notifier.rb
@@ -1,0 +1,7 @@
+class SuccessfulCaptureNotifier
+  def initialize(match)
+  end
+
+  def notify!
+  end
+end

--- a/app/serializers/match_serializer.rb
+++ b/app/serializers/match_serializer.rb
@@ -9,6 +9,10 @@ class MatchSerializer
   belongs_to :opponent
   belongs_to :seeker
 
+  attribute :confirmation_code do |object|
+    object.confirmation_code if object.pending?
+  end
+
   attribute :found_at do |object|
     object.found_at.to_i if object.found?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     resources :devices, only: [:create, :destroy]
     resources :matches, only: :create do
       post :capture, on: :member
+      post :captured, on: :member
     end
     resources :players, only: [:create, :show]
     resources :scores, only: :index

--- a/db/migrate/20180425113154_add_pending_at_to_matches.rb
+++ b/db/migrate/20180425113154_add_pending_at_to_matches.rb
@@ -1,0 +1,5 @@
+class AddPendingAtToMatches < ActiveRecord::Migration[5.1]
+  def change
+    add_column :matches, :pending_at, :datetime
+  end
+end

--- a/db/migrate/20180425120500_add_confirmation_code_to_matches.rb
+++ b/db/migrate/20180425120500_add_confirmation_code_to_matches.rb
@@ -1,0 +1,5 @@
+class AddConfirmationCodeToMatches < ActiveRecord::Migration[5.1]
+  def change
+    add_column :matches, :confirmation_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180425113154) do
+ActiveRecord::Schema.define(version: 20180425120500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 20180425113154) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "pending_at"
+    t.string "confirmation_code"
     t.index ["arena_id"], name: "index_matches_on_arena_id"
     t.index ["opponent_id"], name: "index_matches_on_opponent_id"
     t.index ["seeker_id"], name: "index_matches_on_seeker_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180407195029) do
+ActiveRecord::Schema.define(version: 20180425113154) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 20180407195029) do
     t.datetime "ignored_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "pending_at"
     t.index ["arena_id"], name: "index_matches_on_arena_id"
     t.index ["opponent_id"], name: "index_matches_on_opponent_id"
     t.index ["seeker_id"], name: "index_matches_on_seeker_id"

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -3,6 +3,7 @@ require_relative "exceptions/runtime_error"
 
 require_relative "exceptions/missing_type_parameter_error"
 require_relative "exceptions/parameter_missing_error"
+require_relative "exceptions/precondition_failed_error"
 require_relative "exceptions/not_acceptable_error"
 require_relative "exceptions/not_authorized_error"
 require_relative "exceptions/record_not_found_error"

--- a/lib/jsonapi/exceptions.rb
+++ b/lib/jsonapi/exceptions.rb
@@ -1,6 +1,7 @@
 require_relative "exceptions/error"
 require_relative "exceptions/runtime_error"
 
+require_relative "exceptions/invalid_parameter_error"
 require_relative "exceptions/missing_type_parameter_error"
 require_relative "exceptions/parameter_missing_error"
 require_relative "exceptions/precondition_failed_error"

--- a/lib/jsonapi/exceptions/invalid_parameter_error.rb
+++ b/lib/jsonapi/exceptions/invalid_parameter_error.rb
@@ -1,0 +1,17 @@
+module JSONAPI
+  module Exceptions
+    class InvalidParameterError < Exceptions::RuntimeError
+      def initialize(message)
+        @detail = message
+      end
+
+      def errors
+        [error(
+          status: :bad_request,
+          title: "Invalid parameter",
+          detail: @detail
+        )]
+      end
+    end
+  end
+end

--- a/lib/jsonapi/exceptions/precondition_failed_error.rb
+++ b/lib/jsonapi/exceptions/precondition_failed_error.rb
@@ -1,0 +1,17 @@
+module JSONAPI
+  module Exceptions
+    class PreconditionFailedError < Exceptions::RuntimeError
+      def initialize(message)
+        @detail = message
+      end
+
+      def errors
+        [error(
+          status: :precondition_failed,
+          title: "Precondition failed",
+          detail: @detail
+        )]
+      end
+    end
+  end
+end

--- a/lib/token_generator.rb
+++ b/lib/token_generator.rb
@@ -4,4 +4,8 @@ class TokenGenerator
   def self.generate
     SecureRandom.base64(15).tr("+/=lIO0", "pqrsxyz")
   end
+
+  def self.generate_code(number_of_digits)
+    rand(10 ** number_of_digits).to_s
+  end
 end

--- a/lib/token_generator.rb
+++ b/lib/token_generator.rb
@@ -6,6 +6,6 @@ class TokenGenerator
   end
 
   def self.generate_code(number_of_digits)
-    rand(10 ** number_of_digits).to_s
+    rand(10 ** number_of_digits).to_s.rjust(number_of_digits, "0")
   end
 end

--- a/spec/factories/match_factory.rb
+++ b/spec/factories/match_factory.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     end
 
     trait :pending do
+      confirmation_code { TokenGenerator.generate_code(4) }
       pending_at { DateTime.now }
     end
   end

--- a/spec/factories/match_factory.rb
+++ b/spec/factories/match_factory.rb
@@ -12,5 +12,9 @@ FactoryBot.define do
     trait :ignored do
       ignored_at { DateTime.now }
     end
+
+    trait :pending do
+      pending_at { DateTime.now }
+    end
   end
 end

--- a/spec/jobs/successful_capture_job_spec.rb
+++ b/spec/jobs/successful_capture_job_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe SuccessfulCaptureJob do
+  let(:arena) { create :arena }
+  let(:match) do
+    create :match, :found, arena: arena, seeker: seeker, opponent: opponent
+  end
+  let(:opponent) { create :player, name: "Robert Plant", arenas: [arena] }
+  let(:seeker) { create :player, name: "Jimmy Page", arenas: [arena] }
+
+  before do
+    allow_any_instance_of(SuccessfulCaptureNotifier).to receive(:notify!)
+  end
+
+  it "does not process if the match no longer exists" do
+    match_id = match.id
+
+    match.destroy
+
+    expect { described_class.perform_now match_id }.to_not raise_error
+  end
+
+  it "does not process if it is not a found match" do
+    match.found_at = nil
+    match.ignored!
+
+    expect { described_class.perform_now match.id }.to_not \
+      change { Score.count }
+  end
+
+  it "notifies the players of a successful capture" do
+    expect(SuccessfulCaptureNotifier).to \
+      receive(:new).with(match).and_call_original
+    expect_any_instance_of(SuccessfulCaptureNotifier).to receive(:notify!)
+
+    described_class.perform_now match.id
+  end
+
+  it "scores the match for the players" do
+    expect { described_class.perform_now match.id }.to \
+      change { Score.count }.by(2)
+  end
+end

--- a/spec/lib/token_generator_spec.rb
+++ b/spec/lib/token_generator_spec.rb
@@ -11,4 +11,15 @@ RSpec.describe TokenGenerator do
       expect(tokens.uniq.length).to eq 50
     end
   end
+
+  describe ".generate_code" do
+    it "generates a unique numeric code" do
+      tokens = []
+      50.times do
+        tokens << described_class.generate_code(10)
+      end
+
+      expect(tokens.uniq.length).to eq 50
+    end
+  end
 end

--- a/spec/lib/token_generator_spec.rb
+++ b/spec/lib/token_generator_spec.rb
@@ -21,5 +21,14 @@ RSpec.describe TokenGenerator do
 
       expect(tokens.uniq.length).to eq 50
     end
+
+    it "ensures that they are left padded with zeros" do
+      tokens = []
+      50.times do
+        tokens << described_class.generate_code(10)
+      end
+
+      expect(tokens.all? { |token| token.length == 10 }).to be_truthy
+    end
   end
 end

--- a/spec/models/confirm_capture_notifier_spec.rb
+++ b/spec/models/confirm_capture_notifier_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe ConfirmCaptureNotifier do
+  let(:match) { create :match, :pending, seeker: seeker, opponent: opponent }
+  let(:opponent) { create :player, name: "Robert Plant" }
+  let(:seeker) { create :player, name: "Jimmy Page" }
+  let!(:seeker_device) { create :device, player: seeker }
+
+  before { allow_any_instance_of(Houston::Client).to receive(:push) }
+
+  describe "#initialize" do
+    it "initializes with a match" do
+      expect(described_class.new(match).match).to eq match
+    end
+  end
+
+  describe "#notify_player!" do
+    subject { described_class.new(match) }
+
+    it "creates a push notification for the player" do
+      expect(Houston::Notification).to \
+        receive(:new).with(device: seeker_device.token).and_call_original
+
+      subject.notify_player!(seeker)
+    end
+
+    it "tells the player who caught them" do
+      expect_any_instance_of(Houston::Notification).to \
+        receive(:alert=).with("Gotcha! Looks like you met Robert Plant. "\
+                              "Please confirm with his code.")
+        .and_call_original
+
+      subject.notify_player!(seeker)
+    end
+
+    it "sends the appropriate category" do
+      expect_any_instance_of(Houston::Notification).to \
+        receive(:category=).with(:confirm_capture).and_call_original
+
+      subject.notify_player!(seeker)
+    end
+
+    it "tells the player how many open matches they have" do
+      create :match, opponent: seeker
+
+      expect_any_instance_of(Houston::Notification).to \
+        receive(:badge=).with(1).and_call_original
+
+      subject.notify_player!(seeker)
+    end
+
+    it "passes on the match data" do
+      expect_any_instance_of(Houston::Notification).to \
+        receive(:custom_data=).with(MatchSerializer.new(match).serializable_hash)
+        .and_call_original
+
+      subject.notify_player!(seeker)
+    end
+
+    context "without a device token for the player" do
+      it "does not create a push notification for the player" do
+        expect(Houston::Notification).to_not receive(:new)
+
+        subject.notify_player!(opponent)
+      end
+    end
+  end
+end

--- a/spec/models/match_maker_spec.rb
+++ b/spec/models/match_maker_spec.rb
@@ -39,11 +39,31 @@ RSpec.describe MatchMaker do
 
     context "with two matched players in a previous match" do
       let!(:match) do
-        create :match, :ignored, arena: arena, seeker: player_one, opponent: player_two
+        create :match,
+          :ignored,
+          arena: arena,
+          seeker: player_one,
+          opponent: player_two
       end
 
       it "does not create a match" do
-        expect(described_class.match!(player: player_two, arena: arena)).to be_nil
+        expect(described_class.match!(player: player_two, arena: arena)).to \
+          be_nil
+      end
+    end
+
+    context "with a pending match between players in the same arena" do
+      let!(:match) do
+        create :match,
+          :pending,
+          arena: arena,
+          seeker: player_one,
+          opponent: player_two
+      end
+
+      it "does not create a new match" do
+        expect(described_class.match!(player: player_two, arena: arena)).to \
+          be_nil
       end
     end
 
@@ -53,7 +73,11 @@ RSpec.describe MatchMaker do
       before do
         player_one.arenas << arena2
         player_two.arenas << arena2
-        create :match, :found, arena: arena2, seeker: player_one, opponent: player_two
+        create :match,
+          :found,
+          arena: arena2,
+          seeker: player_one,
+          opponent: player_two
       end
 
       it "creates a new match between the two players" do

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -161,6 +161,22 @@ RSpec.describe Match do
     end
   end
 
+  describe "#pending!" do
+    subject { create :match }
+
+    it "sets the pending_at timestamp" do
+      subject.pending!
+
+      expect(subject.pending_at).to be_within(1.second).of(DateTime.now)
+    end
+
+    it "updates the record" do
+      subject.pending!
+
+      expect(subject).to_not be_changed
+    end
+  end
+
   describe "validations" do
     subject { build :match }
 

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -1,18 +1,46 @@
 require "rails_helper"
 
 RSpec.describe Match do
-  let!(:active) { create :match, seeker: player }
-  let!(:found) { create :match, :found, opponent: player }
-  let!(:ignored) { create :match, :ignored }
   let(:player) { create :player }
 
+  describe "#closed?" do
+    it "is not closed when it is active" do
+      active = build :match
+
+      expect(active).to_not be_closed
+    end
+
+    it "is closed when it is found" do
+      found = build :match, :found
+
+      expect(found).to be_closed
+    end
+
+    it "is closed when it is ignored" do
+      ignored = build :match, :ignored
+
+      expect(ignored).to be_closed
+    end
+
+    it "is closed when it is pending" do
+      pending = build :match, :pending
+
+      expect(pending).to be_closed
+    end
+  end
+
   describe ".for" do
+    let!(:active) { create :match, seeker: player }
+    let!(:found) { create :match, :found, opponent: player }
+
     it "returns all matches for the specified player" do
       expect(described_class.for(player)).to match_array [active, found]
     end
   end
 
   describe ".found" do
+    let!(:found) { create :match, :found, opponent: player }
+
     it "returns all matches that were found" do
       expect(described_class.found).to match_array [found]
     end
@@ -49,6 +77,8 @@ RSpec.describe Match do
   end
 
   describe ".ignored" do
+    let!(:ignored) { create :match, :ignored }
+
     it "returns all matches that were ignored" do
       expect(described_class.ignored).to match_array [ignored]
     end
@@ -88,6 +118,10 @@ RSpec.describe Match do
   end
 
   describe ".open" do
+    let!(:active) { create :match, seeker: player }
+    let!(:found) { create :match, :found, opponent: player }
+    let!(:ignored) { create :match, :ignored }
+
     it "returns all matches that were not found or ignored" do
       expect(described_class.open).to match_array [active]
     end

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -47,18 +47,28 @@ RSpec.describe Match do
   end
 
   describe "#found!" do
-    subject { create :match }
+    subject { create :match, :pending }
 
-    it "sets the found_at timestamp" do
-      subject.found!
+    context "with a correct confirmation code" do
+      it "sets the found_at timestamp" do
+        subject.found!(subject.confirmation_code)
 
-      expect(subject.found_at).to be_within(1.second).of(DateTime.now)
+        expect(subject.found_at).to be_within(1.second).of(DateTime.now)
+      end
+
+      it "updates the record" do
+        subject.found!(subject.confirmation_code)
+
+        expect(subject).to_not be_changed
+      end
     end
 
-    it "updates the record" do
-      subject.found!
+    context "with an incorrect confirmation code" do
+      it "does not set the found_at timestamp" do
+        subject.found!("blah")
 
-      expect(subject).to_not be_changed
+        expect(subject).to_not be_found
+      end
     end
   end
 

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -232,7 +232,21 @@ RSpec.describe Match do
       expect(subject.errors[:base]).to include "Match is not open"
     end
 
-    xit "a pending match must have a confirmation code present"
-    xit "only allows a confirmation code for pending or found matches"
+    it "a pending match must have a confirmation code present" do
+      subject.pending_at = DateTime.now
+
+      expect(subject).to_not be_valid
+      expect(subject.errors[:confirmation_code]).to \
+        include "can't be blank for pending matches"
+    end
+
+    it "only allows a confirmation code for pending or found matches" do
+      subject.ignored_at = DateTime.now
+      subject.confirmation_code = "blah"
+
+      expect(subject).to_not be_valid
+      expect(subject.errors[:confirmation_code]).to \
+        include "must be blank for ignored matches"
+    end
   end
 end

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -170,6 +170,12 @@ RSpec.describe Match do
       expect(subject.pending_at).to be_within(1.second).of(DateTime.now)
     end
 
+    it "generates a 4-digit confirmation code" do
+      subject.pending!
+
+      expect(subject.confirmation_code.length).to eq 4
+    end
+
     it "updates the record" do
       subject.pending!
 

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe Match do
         expect(subject.found_at).to be_within(1.second).of(DateTime.now)
       end
 
+      it "clears the pending status" do
+        subject.found!(subject.confirmation_code)
+
+        expect(subject).to_not be_pending
+      end
+
       it "updates the record" do
         subject.found!(subject.confirmation_code)
 

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -98,6 +98,29 @@ RSpec.describe Match do
     end
   end
 
+  describe "#ignore!" do
+    subject { create :match }
+
+    it "sets the ignored_at timestamp" do
+      subject.ignored!
+
+      expect(subject.ignored_at).to be_within(1.second).of(DateTime.now)
+    end
+
+    it "clears confirmation code" do
+      subject.pending!
+      subject.ignored!
+
+      expect(subject.confirmation_code).to be_nil
+    end
+
+    it "updates the record" do
+      subject.ignored!
+
+      expect(subject).to_not be_changed
+    end
+  end
+
   describe ".in" do
     let(:arena_one) { create :arena }
     let(:arena_two) { create :arena }
@@ -208,5 +231,8 @@ RSpec.describe Match do
       expect(subject).to_not be_valid
       expect(subject.errors[:base]).to include "Match is not open"
     end
+
+    xit "a pending match must have a confirmation code present"
+    xit "only allows a confirmation code for pending or found matches"
   end
 end

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -113,6 +113,20 @@ RSpec.describe Match do
     end
   end
 
+  describe "#pending?" do
+    it "returns true if the pending_at timestamp is set" do
+      subject = build :match, :pending
+
+      expect(subject).to be_pending
+    end
+
+    it "returns false if the pending_at timestamp is not set" do
+      subject = build :match
+
+      expect(subject).to_not be_pending
+    end
+  end
+
   describe "validations" do
     subject { build :match }
 

--- a/spec/models/successful_capture_notifier_spec.rb
+++ b/spec/models/successful_capture_notifier_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe SuccessfulCaptureNotifier do
+  let(:match) { create :match, :found, seeker: seeker, opponent: opponent }
+  let(:opponent) { create :player, name: "Robert Plant" }
+  let(:seeker) { create :player, name: "Jimmy Page" }
+  let!(:seeker_device) { create :device, player: seeker }
+
+  before { allow_any_instance_of(Houston::Client).to receive(:push) }
+
+  describe "#initialize" do
+    it "initializes with a match" do
+      expect(described_class.new(match).match).to eq match
+    end
+  end
+
+  describe "#notify_player!" do
+    subject { described_class.new(match) }
+
+    it "creates a push notification for the player" do
+      expect(Houston::Notification).to \
+        receive(:new).with(device: seeker_device.token).and_call_original
+
+      subject.notify_player!(seeker)
+    end
+
+    it "tells the player who is looking for them" do
+      expect_any_instance_of(Houston::Notification).to \
+        receive(:alert=).with("Gotcha! You just met Robert Plant!")
+        .and_call_original
+
+      subject.notify_player!(seeker)
+    end
+
+    it "sends the appropriate category" do
+      expect_any_instance_of(Houston::Notification).to \
+        receive(:category=).with(:successful_capture).and_call_original
+
+      subject.notify_player!(seeker)
+    end
+
+    it "tells the player how many open matches they have" do
+      create :match, opponent: seeker
+
+      expect_any_instance_of(Houston::Notification).to \
+        receive(:badge=).with(1).and_call_original
+
+      subject.notify_player!(seeker)
+    end
+
+    it "passes on the match data" do
+      expect_any_instance_of(Houston::Notification).to \
+        receive(:custom_data=).with(MatchSerializer.new(match).serializable_hash)
+        .and_call_original
+
+      subject.notify_player!(seeker)
+    end
+
+    context "without a device token for the player" do
+      it "does not create a push notification for the player" do
+        expect(Houston::Notification).to_not receive(:new)
+
+        subject.notify_player!(opponent)
+      end
+    end
+  end
+
+  describe "#notify!" do
+    subject { described_class.new(match) }
+
+    it "notifies the seeker and the opponent" do
+      expect(subject).to receive(:notify_player!).with(match.seeker).ordered
+      expect(subject).to receive(:notify_player!).with(match.opponent).ordered
+
+      subject.notify!
+    end
+  end
+end

--- a/spec/requests/capture_player_spec.rb
+++ b/spec/requests/capture_player_spec.rb
@@ -19,14 +19,10 @@ RSpec.describe "POST /api/matches/:id/capture" do
       expect(match.reload).to be_pending
     end
 
-    it "creates a new match for the seeker" do
-      expect { post url, headers: valid_authed_headers }.to \
-        have_enqueued_job(MakeMatchJob).with(match.seeker_id, match.arena_id)
-    end
+    it "generates a confirmation code for the match" do
+      post url, headers: valid_authed_headers
 
-    it "creates a new match for the opponent" do
-      expect { post url, headers: valid_authed_headers }.to \
-        have_enqueued_job(MakeMatchJob).with(match.opponent_id, match.arena_id)
+      expect(match.reload.confirmation_code.length).to eq 4
     end
 
     it "returns the json representation of the match" do
@@ -34,6 +30,8 @@ RSpec.describe "POST /api/matches/:id/capture" do
 
       expect(json_response[:data][:type]).to eq "match"
       expect(json_response[:data][:id]).to eq match.id.to_s
+      expect(json_response[:data][:attributes][:confirmation_code]).to \
+        eq match.reload.confirmation_code
     end
   end
 

--- a/spec/requests/capture_player_spec.rb
+++ b/spec/requests/capture_player_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe "POST /api/matches/:id/capture" do
       expect(response).to be_ok
     end
 
-    it "marks the match as found" do
+    it "marks the match as pending" do
       post url, headers: valid_authed_headers
 
-      expect(match.reload).to be_found
+      expect(match.reload).to be_pending
     end
 
     it "creates a new match for the seeker" do

--- a/spec/requests/confirm_captured_player_spec.rb
+++ b/spec/requests/confirm_captured_player_spec.rb
@@ -75,7 +75,24 @@ RSpec.describe "POST /api/matches/:id/captured" do
   end
 
   context "with a confirmation code that does not match" do
-    xit "returns an unprocessable entity status"
+    let(:parameters) do
+      {
+        data: {
+          type: "match",
+          attributes: {
+            confirmation_code: "blah"
+          }
+        }
+      }.to_json
+    end
+
+    it "returns a bad request status" do
+      post url, params: parameters, headers: valid_authed_headers
+
+      expect(response).to be_bad_request
+      expect(json_response[:errors].map { |error| error[:detail] }).to \
+        include "Confirmation code does not match"
+    end
   end
 
   context "with an arena that the player is not playing in" do

--- a/spec/requests/confirm_captured_player_spec.rb
+++ b/spec/requests/confirm_captured_player_spec.rb
@@ -1,0 +1,53 @@
+require "request_helper"
+
+RSpec.describe "POST /api/matches/:id/captured" do
+  let(:arena) { create :arena }
+  let(:match) { create :match, :pending, arena: arena, seeker: player }
+  let(:player) { create :player, :authorized, arenas: [arena] }
+  let(:url) { "/api/matches/#{match.id}/captured" }
+  let(:valid_parameters) do
+    {
+      data: {
+        type: "match",
+        attributes: {
+          confirmation_code: match.confirmation_code
+        }
+      }
+    }.to_json
+  end
+
+  context "with a valid request" do
+    it "returns an ok status" do
+      post url, params: valid_parameters, headers: valid_authed_headers
+
+      expect(response).to be_ok
+    end
+
+    it "marks the match as found" do
+      post url, params: valid_parameters, headers: valid_authed_headers
+
+      expect(match.reload).to be_found
+    end
+
+    it "creates a new match for the seeker" do
+      expect { post url, params: valid_parameters,
+                         headers: valid_authed_headers }.to \
+        have_enqueued_job(MakeMatchJob).with(match.seeker_id, match.arena_id)
+    end
+
+    it "creates a new match for the opponent" do
+      expect { post url, params: valid_parameters,
+                         headers: valid_authed_headers }.to \
+        have_enqueued_job(MakeMatchJob).with(match.opponent_id, match.arena_id)
+    end
+
+    it "returns the json representation of the match" do
+      post url, params: valid_parameters, headers: valid_authed_headers
+
+      expect(json_response[:data][:type]).to eq "match"
+      expect(json_response[:data][:id]).to eq match.id.to_s
+      expect(json_response[:data][:attributes][:confirmation_code]).to \
+        be_nil
+    end
+  end
+end

--- a/spec/requests/confirm_captured_player_spec.rb
+++ b/spec/requests/confirm_captured_player_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe "POST /api/matches/:id/captured" do
       expect(match.reload).to be_found
     end
 
+    it "processes the successful match" do
+      expect { post url, params: valid_parameters,
+                         headers: valid_authed_headers }.to \
+        have_enqueued_job(SuccessfulCaptureJob).with(match.id)
+    end
+
     it "creates a new match for the seeker" do
       expect { post url, params: valid_parameters,
                          headers: valid_authed_headers }.to \

--- a/spec/serializers/match_serializer_spec.rb
+++ b/spec/serializers/match_serializer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe MatchSerializer do
 
     it "serializes the attributes" do
       expect(hash[:attributes].keys).to \
-        match_array [:found_at, :matched_at]
+        match_array [:confirmation_code, :found_at, :matched_at]
     end
 
     it "returns the datetimes in unix Epoch time" do


### PR DESCRIPTION
This adds a captured player endpoint `POST /api/matches/:id/captured`.

The flow goes like this:

1. The player who "hits the captured button on a new match" will receive a confirmation code from the capture endpoint when it is hit via `POST /api/matches/:id/capture`.
2. This puts the `Match` in `pending` status and no new matches can occur for the players in that arena
3. The player who "hit the button" will tell the opponent what the code is because "the UI was updated with the code"
4. The opponent enters in the code because they should of received a `confirm_capture` push notification and their screen should now show the ability to enter it
5. One the opponent enters it, it hits this endpoint
6. Each player should of received a `successful_capture` push notification

This PR handles the backend for all of the above.