### PR TITLE
Retrieve Matches

### DIFF
--- a/lib/gotcha_web/graphql/resolvers/matches.ex
+++ b/lib/gotcha_web/graphql/resolvers/matches.ex
@@ -1,0 +1,16 @@
+defmodule GotchaWeb.GraphQL.Resolvers.Matches do
+  alias Gotcha.{Match, MatchMaker, Repo}
+
+  def inside(_parent, %{arena_id: arena_id}, %{context: %{current_player: current_player}}) do
+    MatchMaker.match(arena_id, current_player.id)
+
+    matches =
+      Match
+      |> Match.inside(arena_id)
+      |> Match.with(current_player.id)
+      |> Repo.all()
+      |> Enum.map(fn match -> Gotcha.Repo.preload(match, [:arena, :opponent, :player]) end)
+
+    {:ok, matches}
+  end
+end

--- a/lib/gotcha_web/graphql/schema.ex
+++ b/lib/gotcha_web/graphql/schema.ex
@@ -20,6 +20,13 @@ defmodule GotchaWeb.GraphQL.Schema do
 
       resolve(&Resolvers.Arenas.nearby/3)
     end
+
+    @desc "Matches that are in the specified arena for the current player"
+    field :matches, list_of(:match) do
+      arg(:arena_id, non_null(:integer), description: "The id of the arena to find the matches in")
+
+      resolve(&Resolvers.Matches.inside/3)
+    end
   end
 
   @desc "All mutations that can be performed within Gotcha"

--- a/lib/gotcha_web/graphql/schema/types.ex
+++ b/lib/gotcha_web/graphql/schema/types.ex
@@ -1,6 +1,8 @@
 defmodule GotchaWeb.GraphQL.Schema.Types do
   use Absinthe.Schema.Notation
 
+  import_types(Absinthe.Type.Custom)
+
   alias GotchaWeb.GraphQL.Plugs.TokenAuth
 
   @desc "Represents a place where a game can take place"
@@ -43,6 +45,24 @@ defmodule GotchaWeb.GraphQL.Schema.Types do
 
     @desc "The player that is in the arena."
     field(:player, non_null(:player))
+  end
+
+  @desc "Represents a game between two players inside an arena"
+  object :match do
+    @desc "The unique identifier for the match."
+    field(:id, non_null(:id))
+
+    @desc "The date and time that the match was created."
+    field(:matched_at, non_null(:naive_datetime))
+
+    @desc "The place where the match is being played."
+    field(:arena, non_null(:arena))
+
+    @desc "The player that is in the match."
+    field(:player, non_null(:player))
+
+    @desc "The opponent against the player in the match."
+    field(:opponent, non_null(:player))
   end
 
   @desc "Represents a player who is playing the game"

--- a/test/gotcha_web/graphql/requests/arena_matches_test.exs
+++ b/test/gotcha_web/graphql/requests/arena_matches_test.exs
@@ -1,0 +1,82 @@
+defmodule GotchaWeb.GraphQL.Requests.ArenaMatchesTest do
+  use GotchaWeb.ConnCase, async: true
+
+  import Gotcha.Factory
+  import GotchaWeb.ConnCaseHelpers
+  import GotchaWeb.GraphQLHelpers
+
+  alias Gotcha.{Match, Repo}
+
+  describe "with a valid query" do
+    setup do
+      arena = insert(:arena)
+      player = insert(:player)
+      insert(:arena_player, arena: arena, player: player)
+
+      query = """
+      {
+        matches(arena_id: #{arena.id}) {
+          player {
+            name
+          }
+          opponent {
+            name
+          }
+        }
+      }
+      """
+
+      conn =
+        build_conn()
+        |> authenticate_with_jwt_token(player)
+        |> put_graphql_headers
+
+      [conn: conn, query: query, arena: arena, player: player]
+    end
+
+    test "returns the matches within the arena for the current player", %{
+      conn: conn,
+      query: query,
+      arena: arena,
+      player: player
+    } do
+      opponent = insert(:player)
+      insert(:arena_player, arena: arena, player: opponent)
+      insert(:match, arena: arena, player: player, opponent: opponent)
+
+      conn = conn |> post("/graphql", query)
+
+      assert json_response(conn, 200) == %{
+               "data" => %{
+                 "matches" => [
+                   %{
+                     "player" => %{
+                       "name" => player.name
+                     },
+                     "opponent" => %{
+                       "name" => opponent.name
+                     }
+                   }
+                 ]
+               }
+             }
+    end
+
+    test "creates a match if one is not available", %{
+      conn: conn,
+      query: query,
+      arena: arena,
+      player: player
+    } do
+      opponent = insert(:player)
+      insert(:arena_player, arena: arena, player: opponent)
+
+      conn |> post("/graphql", query)
+
+      match = Match |> Ecto.Query.last() |> Repo.one()
+
+      assert match.player_id == player.id
+      assert match.arena_id == arena.id
+    end
+  end
+end


### PR DESCRIPTION
The PR adds a new query endpoint to allow a Player to retrieve all of their matches for a specific Arena.

```
query matches($arenaId: Int!) {
  matches(arenaId: $arenaId) {
    id
    arena {
      locationName
    }
    player {
      name
    }
    opponent {
      name
    }
  }
}
```

Closes #13 